### PR TITLE
Update `QUBOTools -> v0.9, QUBODrivers -> v0.3, DWave->0.4`

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,3 @@
+align_assignment = true
+align_pair_arrow = true
+align_matrix     = true

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,7 +4,7 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.7,<=3.11"
 
 [pip.deps]
-numpy           = ">=1.20"
-matplotlib      = ">=3.5"
+# numpy           = ">=1.20"
+# matplotlib      = ">=3.5"
 dwave-ocean-sdk = "==6.4.1"
 dwave_networkx  = "==0.8.14"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,10 @@ authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@p
 version = "0.4.0"
 
 [deps]
-PythonCall  = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
-QUBOTools   = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 
 [compat]
-PythonCall  = "0.9.14"
+PythonCall = "0.9.14"
 QUBODrivers = "0.3"
-julia       = "1.9"
+julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,14 @@
-name    = "DWave"
-uuid    = "4d534982-bf11-4157-9e48-fe3a62208a50"
-authors = [
-    "pedromxavier <pedroxavier@psr-inc.com>",
-    "pedroripper <pedroripper@psr-inc.com>",
-]
-version = "0.3.1"
+name = "DWave"
+uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
+authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>"]
+version = "0.4.0"
 
 [deps]
 PythonCall  = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
+QUBOTools   = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 
 [compat]
-PythonCall  = "0.9.13"
-QUBODrivers = "0.2"
-julia       = "1.6"
+PythonCall  = "0.9.14"
+QUBODrivers = "0.3"
+julia       = "1.9"

--- a/src/DWave.jl
+++ b/src/DWave.jl
@@ -1,20 +1,13 @@
 module DWave
 
+import QUBODrivers
+import QUBODrivers: MOI, QUBOTools
+
 using PythonCall
 
-import QUBODrivers:
-    MOI,
-    QUBODrivers,
-    QUBOTools,
-    Sample,
-    SampleSet,
-    @setup,
-    sample,
-    ising
-
 # -*- :: Python D-Wave Module :: -*- #
-const np  = PythonCall.pynew()
-const plt = PythonCall.pynew()
+# const np  = PythonCall.pynew()
+# const plt = PythonCall.pynew()
 const dwave_cloud     = PythonCall.pynew()
 const dwave_dimod     = PythonCall.pynew()
 const dwave_embedding = PythonCall.pynew()
@@ -23,8 +16,8 @@ const dwave_system    = PythonCall.pynew()
 
 function __init__()
     # Python Packages
-    PythonCall.pycopy!(np, pyimport("numpy"))
-    PythonCall.pycopy!(plt, pyimport("matplotlib.pyplot"))
+    # PythonCall.pycopy!(np, pyimport("numpy"))
+    # PythonCall.pycopy!(plt, pyimport("matplotlib.pyplot"))
     PythonCall.pycopy!(dwave_cloud, pyimport("dwave.cloud"))
     PythonCall.pycopy!(dwave_dimod, pyimport("dimod"))
     PythonCall.pycopy!(dwave_embedding, pyimport("dwave.embedding"))
@@ -42,76 +35,7 @@ function __init__()
     end
 end
 
-@setup Optimizer begin
-    name       = "D-Wave"
-    sense      = :min
-    domain     = :spin
-    version    = v"6.4.1" # dwave-ocean-sdk version
-    attributes = begin
-        NumberOfReads["num_reads"]::Integer = 100
-        Sampler["sampler"]::Any             = nothing
-    end
-end
-
-function sample(sampler::Optimizer{T}) where {T}
-    # Ising Model
-    h, J, α, β = ising(sampler, Dict)
-
-    n = MOI.get(sampler, MOI.NumberOfVariables())
-
-    # Attributes
-    num_reads     = MOI.get(sampler, DWave.NumberOfReads())
-    dwave_sampler = MOI.get(sampler, DWave.Sampler())
-
-    if dwave_sampler === nothing
-        dwave_sampler = dwave_system.EmbeddingComposite(
-            dwave_system.DWaveSampler(;
-                token = get(ENV, "DWAVE_API_TOKEN", nothing)
-            )
-        )
-    end
-
-    # Extra Information
-    metadata = Dict{String,Any}(
-        "time"   => Dict{String,Any}(),
-        "origin" => "D-Wave",
-    )
-
-    # Results vector
-    samples = Sample{T,Int}[]
-
-    results = @timed dwave_sampler.sample_ising(h, J; num_reads=num_reads)
-    var_map = pyconvert.(Int, results.value.variables)
-
-    for (ϕ, λ, r) in results.value.record
-        # the dwave sampler will not consider variables that are not
-        # present in the objective funcion, leading to holes with
-        # respect to the indices in the record table.
-        # Therefore, it is necessary to introduce an extra layer of
-        # indirection to account for the missing variables.
-        ψ = zeros(Int, n)
-
-        for (i, v) in enumerate(ϕ)
-            ψ[var_map[i]] = pyconvert(Int, v)
-        end
-
-        sample = Sample{T,Int}(
-            # state:
-            ψ,
-            # energy:
-            α * (pyconvert(T, λ) + β),
-            # reads:
-            pyconvert(Int, r),
-        )
-
-        push!(samples, sample)
-    end
-
-    metadata["dwave_info"] = results.value.info
-
-    metadata["time"]["effective"] = results.time
-
-    return SampleSet{T}(samples, metadata)
-end
+include("sampler.jl")
+include("neal.jl")
 
 end # module

--- a/src/neal.jl
+++ b/src/neal.jl
@@ -1,0 +1,101 @@
+module Neal
+
+import QUBODrivers
+import QUBODrivers: MOI, QUBOTools 
+
+using PythonCall
+
+# -*- :: Python D-Wave Simulated Annealing :: -*- #
+const neal = PythonCall.pynew() # initially NULL
+
+function __init__()
+    PythonCall.pycopy!(neal, pyimport("neal"))
+end
+
+const ATTRIBUTES = [
+    :num_reads,
+    :num_sweeps,
+    :num_sweeps_per_beta,
+    :beta_range,
+    :beta_schedule,
+    :beta_schedule_type,
+    :seed,
+    :initial_states_generator,
+    :interrupt_function,
+]
+
+@doc raw"""
+    DWave.Neal.Optimizer
+
+D-Wave's Simulated Annealing Sampler for QUBO and Ising models.
+"""
+QUBODrivers.@setup Optimizer begin
+    name       = "D-Wave Neal Simulated Annealing Sampler"
+    version    = v"6.4.1" # dwave-ocean-sdk version
+    attributes = begin
+        "num_reads"::Integer = 1_000
+        "num_sweeps"::Integer = 1_000
+        "num_sweeps_per_beta"::Integer = 1
+        "beta_range"::Union{Tuple{Float64,Float64},Nothing} = nothing
+        "beta_schedule"::Union{Vector,Nothing} = nothing
+        "beta_schedule_type"::String = "geometric"
+        "seed"::Union{Integer,Nothing} = nothing
+        "initial_states_generator"::String = "random"
+        "interrupt_function"::Union{Function,Nothing} = nothing
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    # Retrieve Ising Model
+    n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
+
+    # Retrieve Optimizer Attributes
+    params = Dict{Symbol,Any}(
+        param => MOI.get(sampler, MOI.RawOptimizerAttribute(string(param)))
+        for param in ATTRIBUTES
+    )
+
+    # Call D-Wave Neal API
+    sampler = neal.SimulatedAnnealingSampler()
+    results = @timed sampler.sample_ising(h, J; params...)
+
+    # Format Samples
+    samples = QUBOTools.Sample{T,Int}[]
+    var_map = pyconvert.(Int, results.value.variables)
+
+    for (ϕ, λ, r) in results.value.record
+        # the dwave sampler will not consider variables that are not
+        # present in the objective funcion, leading to holes with
+        # respect to the indices in the record table.
+        # Therefore, it is necessary to introduce an extra layer of
+        # indirection to account for the missing variables.
+        ψ = zeros(Int, n)
+
+        for (i, v) in enumerate(ϕ)
+            ψ[var_map[i]] = pyconvert(Int, v)
+        end
+
+        sample = QUBOTools.Sample{T,Int}(
+            # state:
+            ψ,
+            # energy:
+            α * (pyconvert(T, λ) + β),
+            # reads:
+            pyconvert(Int, r),
+        )
+
+        push!(samples, sample)
+    end
+
+    # Write metadata
+    metadata = Dict{String,Any}(
+        "origin" => "D-Wave Neal",
+        "time"   => Dict{String,Any}( #
+            "effective" => results.time
+        ),
+    )
+
+    return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
+end
+
+end # module Neal

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -1,0 +1,71 @@
+@doc raw"""
+    DWave.Optimizer
+
+D-Wave's Quantum Annealing Sampler for QUBO and Ising models.
+"""
+QUBODrivers.@setup Optimizer begin
+    name       = "D-Wave Quantum Annealing Sampler"
+    version    = v"6.4.1" # dwave-ocean-sdk version
+    attributes = begin
+        NumberOfReads["num_reads"]::Integer = 100
+        Sampler["sampler"]::Any             = nothing
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    # Ising Model
+    n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
+
+    # Attributes
+    num_reads     = MOI.get(sampler, DWave.NumberOfReads())
+    dwave_sampler = MOI.get(sampler, DWave.Sampler())
+
+    if dwave_sampler === nothing
+        dwave_sampler = dwave_system.EmbeddingComposite(
+            dwave_system.DWaveSampler(;
+                token = get(ENV, "DWAVE_API_TOKEN", nothing)
+            )
+        )
+    end
+
+    # Results vector
+    samples = QUBOTools.Sample{T,Int}[]
+
+    results = @timed dwave_sampler.sample_ising(h, J; num_reads=num_reads)
+    var_map = pyconvert.(Int, results.value.variables)
+
+    for (ϕ, λ, r) in results.value.record
+        # the dwave sampler will not consider variables that are not
+        # present in the objective funcion, leading to holes with
+        # respect to the indices in the record table.
+        # Therefore, it is necessary to introduce an extra layer of
+        # indirection to account for the missing variables.
+        ψ = zeros(Int, n)
+
+        for (i, v) in enumerate(ϕ)
+            ψ[var_map[i]] = pyconvert(Int, v)
+        end
+
+        sample = QUBOTools.Sample{T,Int}(
+            # state:
+            ψ,
+            # energy:
+            α * (pyconvert(T, λ) + β),
+            # reads:
+            pyconvert(Int, r),
+        )
+
+        push!(samples, sample)
+    end
+
+    # Metadata
+    metadata = Dict{String,Any}(
+        "origin" => "D-Wave",
+        "time"   => Dict{String,Any}( #
+            "effective" => results.time,
+        ),
+        "dwave_info" => results.value.info
+    )
+
+    return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 using DWave: DWave, QUBODrivers
 
 QUBODrivers.test(DWave.Optimizer; examples = true)
+QUBODrivers.test(DWave.Neal.Optimizer; examples = true)


### PR DESCRIPTION
Besides adjusting for updates on [QUBODrivers.jl](https://github.com/psrenergy/QUBODrivers.jl) and [QUBOTools.jl](https://github.com/psrenergy/QUBOTools.jl), this PR embeds [DWaveNeal.jl](QUBODrivers.jl](https://github.com/psrenergy/DWaveNeal.jl)) as a submodule of [DWave.jl](https://github.com/psrenergy/DWave.jl). Its solver is now published as `DWave.Neal.Optimizer`.