### PR TITLE
[codex] Fix Neal parity with direct dwave.samplers

### DIFF
--- a/src/neal/sampler.jl
+++ b/src/neal/sampler.jl
@@ -56,7 +56,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
     # Call D-Wave Neal API
     sampler = dwave_samplers.SimulatedAnnealingSampler()
-    results = @timed sampler.sample_ising(np.array(h), np.array(J); params...)
+    results = @timed sampler.sample_ising(Py(h), Py(J); params...)
 
     # Format Samples
     samples = QUBOTools.Sample{T,Int}[]

--- a/src/neal/sampler.jl
+++ b/src/neal/sampler.jl
@@ -7,9 +7,11 @@ import MathOptInterface as MOI
 using PythonCall
 
 # -*- :: Python D-Wave Simulated Annealing :: -*- #
+const np = PythonCall.pynew() # initially NULL
 const dwave_samplers = PythonCall.pynew() # initially NULL
 
 function __init__()
+    PythonCall.pycopy!(np, pyimport("numpy"))
     # Note: 'neal' package was deprecated and replaced by 'dwave.samplers' in dwave-ocean-sdk 8.0+
     PythonCall.pycopy!(dwave_samplers, pyimport("dwave.samplers"))
 end
@@ -37,7 +39,7 @@ end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     # Retrieve Ising Model
-    n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
+    n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
 
     # Retrieve Optimizer Attributes
     params = Dict{Symbol,Any}(
@@ -54,11 +56,12 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
     # Call D-Wave Neal API
     sampler = dwave_samplers.SimulatedAnnealingSampler()
-    results = @timed sampler.sample_ising(h, J; params...)
+    results = @timed sampler.sample_ising(np.array(h), np.array(J); params...)
 
     # Format Samples
     samples = QUBOTools.Sample{T,Int}[]
-    var_map = pyconvert.(Int, [var for var in results.value.variables])
+    # NumPy-array Ising inputs label variables 0:(n-1) on the Python side.
+    var_map = pyconvert.(Int, [var for var in results.value.variables]) .+ 1
 
     for (ϕ, λ, r) in results.value.record
         # the dwave sampler will not consider variables that are not

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+Random      = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
+QUBOTools   = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 Test        = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/neal_parity.jl
+++ b/test/neal_parity.jl
@@ -1,0 +1,211 @@
+import Test
+import QUBOTools
+
+const MOI = QUBODrivers.MOI
+const NealRecord = NamedTuple{(:energy, :reads, :state),Tuple{Float64,Int,Tuple{Vararg{Int}}}}
+const NealPyException = DWave.Neal.PythonCall.PyException
+
+function _random_ising_instance(n::Int, seed::Int)
+    rng = Random.MersenneTwister(seed)
+
+    h = randn(rng, n)
+    J = zeros(Float64, n, n)
+
+    for i in 1:n, j in (i + 1):n
+        J[i, j] = randn(rng)
+    end
+
+    return h, J
+end
+
+function _direct_neal_records(h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    results = DWave.Neal.dwave_samplers.SimulatedAnnealingSampler().sample_ising(
+        DWave.Neal.np.array(h),
+        DWave.Neal.np.array(J);
+        kwargs...,
+    )
+
+    n = length(h)
+    var_map = DWave.Neal.PythonCall.pyconvert.(Int, [var for var in results.variables]) .+ 1
+    records = NealRecord[]
+
+    for (ϕ, λ, r) in results.record
+        ψ = zeros(Int, n)
+
+        for (i, v) in enumerate(ϕ)
+            ψ[var_map[i]] = DWave.Neal.PythonCall.pyconvert(Int, v)
+        end
+
+        push!(
+            records,
+            (
+                energy = DWave.Neal.PythonCall.pyconvert(Float64, λ),
+                reads = DWave.Neal.PythonCall.pyconvert(Int, r),
+                state = Tuple(ψ),
+            ),
+        )
+    end
+
+    sort!(records; by = r -> (r.energy, r.reads, r.state))
+
+    return records
+end
+
+function _aggregate_records(records::Vector{NealRecord})
+    aggregated = Dict{Tuple{Float64,Tuple},Int}()
+
+    for record in records
+        key = (record.energy, record.state)
+        aggregated[key] = get(aggregated, key, 0) + record.reads
+    end
+
+    normalized = NealRecord[]
+
+    for ((energy, state), reads) in aggregated
+        push!(normalized, (energy = energy, reads = reads, state = state))
+    end
+
+    sort!(normalized; by = r -> (r.energy, r.reads, r.state))
+
+    return normalized
+end
+
+function _wrapper_neal_model(h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    n = length(h)
+    model = MOI.instantiate(DWave.Neal.Optimizer; with_bridge_type = Float64)
+    s, _ = MOI.add_constrained_variables(model, fill(QUBODrivers.Spin(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarQuadraticTerm{Float64}[
+                MOI.ScalarQuadraticTerm{Float64}(J[i, j], s[i], s[j]) for i in 1:n for j in (i + 1):n
+            ],
+            MOI.ScalarAffineTerm{Float64}[MOI.ScalarAffineTerm{Float64}(h[i], s[i]) for i in 1:n],
+            0.0,
+        ),
+    )
+
+    for (name, value) in pairs(kwargs)
+        MOI.set(model, MOI.RawOptimizerAttribute(String(name)), value)
+    end
+
+    return model, s
+end
+
+function _wrapper_neal_records(h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    model, s = _wrapper_neal_model(h, J; kwargs...)
+    QUBOTools_MOI = Base.get_extension(QUBOTools, :QUBOTools_MOI)
+
+    @assert !isnothing(QUBOTools_MOI)
+
+    MOI.optimize!(model)
+
+    records = NealRecord[]
+
+    for i in 1:MOI.get(model, MOI.ResultCount())
+        push!(
+            records,
+            (
+                energy = MOI.get(model, MOI.ObjectiveValue(i)),
+                reads = MOI.get(model, QUBOTools_MOI.NumberOfReads(i)),
+                state = Tuple(Int(round(MOI.get(model, MOI.VariablePrimal(i), v))) for v in s),
+            ),
+        )
+    end
+
+    sort!(records; by = r -> (r.energy, r.reads, r.state))
+
+    return records
+end
+
+function _wrapper_neal_error(h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    model, _ = _wrapper_neal_model(h, J; kwargs...)
+
+    try
+        MOI.optimize!(model)
+        return nothing
+    catch err
+        return err
+    end
+end
+
+Test.@testset "Neal parity with direct dwave.samplers" begin
+    h, J = _random_ising_instance(100, 42)
+
+    for schedule in ("geometric", "linear")
+        Test.@testset "schedule=$schedule" begin
+            kwargs = (
+                num_reads = 128,
+                num_sweeps = 85,
+                beta_schedule_type = schedule,
+                seed = 123_456,
+            )
+
+            direct_records = _aggregate_records(_direct_neal_records(h, J; kwargs...))
+            wrapper_records = _aggregate_records(_wrapper_neal_records(h, J; kwargs...))
+
+            Test.@test wrapper_records == direct_records
+        end
+    end
+end
+
+Test.@testset "Neal wrapper seed determinism" begin
+    h, J = _random_ising_instance(40, 314)
+    kwargs = (
+        num_reads = 64,
+        num_sweeps = 50,
+        beta_schedule_type = "geometric",
+        seed = 202_603_27,
+    )
+
+    records_a = _aggregate_records(_wrapper_neal_records(h, J; kwargs...))
+    records_b = _aggregate_records(_wrapper_neal_records(h, J; kwargs...))
+
+    Test.@test records_a == records_b
+end
+
+Test.@testset "Neal wrapper schedule validation" begin
+    h = [0.0, -1.0]
+    J = zeros(Float64, 2, 2)
+    J[1, 2] = -1.0
+
+    for (kwargs, message) in (
+        ((; num_reads = 1, beta_schedule_type = "asd"), "Beta schedule type asd not implemented"),
+        ((; num_reads = 1, beta_schedule_type = "custom"), "'beta_schedule' must be provided"),
+        (
+            (; num_reads = 1, beta_schedule_type = "linear", beta_schedule = [0.1, 1.0]),
+            "'beta_schedule' must be set to None",
+        ),
+    )
+        err = _wrapper_neal_error(h, J; kwargs...)
+
+        Test.@test err isa NealPyException
+        Test.@test occursin(message, err === nothing ? "" : sprint(showerror, err))
+    end
+end
+
+Test.@testset "Neal parity with sparse support" begin
+    h = zeros(Float64, 8)
+    h[2] = -0.75
+    h[7] = 0.25
+
+    J = zeros(Float64, 8, 8)
+    J[1, 5] = -1.0
+    J[3, 4] = 0.5
+
+    kwargs = (
+        num_reads = 64,
+        num_sweeps = 40,
+        beta_schedule_type = "geometric",
+        seed = 9_191,
+    )
+
+    direct_records = _aggregate_records(_direct_neal_records(h, J; kwargs...))
+    wrapper_records = _aggregate_records(_wrapper_neal_records(h, J; kwargs...))
+
+    Test.@test wrapper_records == direct_records
+    Test.@test all(all(abs.(record.state) .== 1) for record in wrapper_records)
+end

--- a/test/neal_parity.jl
+++ b/test/neal_parity.jl
@@ -1,3 +1,6 @@
+import DWave
+import QUBODrivers
+import Random
 import Test
 import QUBOTools
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 import DWave
 import QUBODrivers
+import Random
 
 if DWave.__auth__(; verbose = false)
     QUBODrivers.test(DWave.Optimizer; examples = true)
@@ -8,3 +9,5 @@ else
 end
 
 QUBODrivers.test(DWave.Neal.Optimizer; examples = true)
+
+include("neal_parity.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 import DWave
 import QUBODrivers
-import Random
 
 if DWave.__auth__(; verbose = false)
     QUBODrivers.test(DWave.Optimizer; examples = true)


### PR DESCRIPTION
## Summary
Fix the `DWave.Neal.Optimizer` wrapper so it matches direct `dwave.samplers` for the same Ising instance, sampler options, and seed.

Closes #15.

## What Changed
- pass dense Ising data to Python as NumPy arrays instead of Julia dictionaries
- remap Python's zero-based variable labels back to Julia's one-based indices when reconstructing samples
- add regression tests for direct parity against `dwave.samplers` under both `geometric` and `linear` schedules
- add wrapper-focused tests for seed determinism, schedule validation, and sparse/disconnected support

## Root Cause
The wrapper was calling `sample_ising` through a different input path than direct `dwave.samplers`, and the sample reconstruction logic assumed the Python-side variable labels already matched Julia's indexing.

## Impact
`DWave.Neal.Optimizer` now reproduces the same sampled outcomes as direct `dwave.samplers` for the tested Ising inputs, which removes the mismatch seen in downstream benchmarking.

## Validation
- `JULIA_DEPOT_PATH=$PWD/.julia-depot:$HOME/.julia JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/home/bernalde/repos/QuIP/.venv/bin/python julia --project=. -e 'using Pkg; Pkg.test()'`
- cloud-backed `DWave.Optimizer` tests were skipped because `DWAVE_API_TOKEN` is not set
