### PR TITLE
[codex] Add classical dwave-samplers wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ for i = 1:result_count(model)
 end
 ```
 
+## Classical Samplers
+`DWave.jl` also exposes wrappers for the classical samplers shipped in
+`dwave-samplers`:
+
+- `DWave.Neal.Optimizer`
+- `DWave.Greedy.Optimizer`
+- `DWave.Random.Optimizer`
+- `DWave.Tabu.Optimizer`
+
+The upstream `planar` and `tree` samplers are not wrapped yet. `PlanarGraphSolver`
+only applies to planar Ising models without linear biases, and the tree
+decomposition samplers expose exact-solver and marginal APIs that do not fit the
+current `QUBODrivers` interface cleanly.
+
 ## API Token
 To use D-Wave's QPU it is necessary to obtain an API Token from [Leap](https://cloud.dwavesys.com/leap/).
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,64 @@ for i = 1:result_count(model)
 end
 ```
 
+## Sampler Overview
+`DWave.jl` provides two families of optimizers:
+
+- `DWave.Optimizer` connects to D-Wave cloud samplers and requires access to a
+  Leap account.
+- `DWave.Neal.Optimizer`, `DWave.Greedy.Optimizer`,
+  `DWave.Random.Optimizer`, and `DWave.Tabu.Optimizer` wrap the classical
+  samplers shipped in `dwave-samplers` and run locally through the
+  PythonCall/CondaPkg environment managed by the package.
+
+Switching between them only requires changing the optimizer passed to
+`Model(...)`.
+
 ## Classical Samplers
-`DWave.jl` also exposes wrappers for the classical samplers shipped in
-`dwave-samplers`:
+The classical samplers expose the same QUBO/Ising modeling interface as the QPU
+wrapper, but they do not require `DWAVE_API_TOKEN`.
 
 - `DWave.Neal.Optimizer`
 - `DWave.Greedy.Optimizer`
 - `DWave.Random.Optimizer`
 - `DWave.Tabu.Optimizer`
+
+Example:
+
+```julia
+using JuMP
+using QUBO
+using DWave
+
+model = Model(DWave.Tabu.Optimizer)
+
+set_attribute(model, "num_reads", 32)
+set_attribute(model, "timeout", 100)
+set_attribute(model, "initial_states", [
+     1  1 -1 -1
+    -1 -1  1  1
+])
+
+h = [-1, -1, 0, 0]
+J = [0 0 1 0; 0 0 0 1; 0 0 0 0; 0 0 0 0]
+
+@variable(model, s[1:4], Spin)
+@objective(model, Min, h' * s + s' * J * s)
+
+optimize!(model)
+```
+
+Sampler-specific options are forwarded as raw optimizer attributes via
+`set_attribute(model, name, value)`. For `initial_states`, the Greedy and Tabu
+wrappers accept either a single Julia vector or a matrix whose rows are initial
+states.
+
+| Optimizer | Description | Raw optimizer attributes |
+| --- | --- | --- |
+| `DWave.Neal.Optimizer` | Simulated annealing baseline. | `num_reads`, `num_sweeps`, `num_sweeps_per_beta`, `beta_range`, `beta_schedule`, `beta_schedule_type`, `seed`, `initial_states_generator`, `interrupt_function` |
+| `DWave.Greedy.Optimizer` | Steepest-descent local search. | `num_reads`, `initial_states`, `initial_states_generator`, `seed`, `large_sparse_opt` |
+| `DWave.Random.Optimizer` | Random-state sampling. | `num_reads`, `time_limit`, `max_num_samples`, `seed` |
+| `DWave.Tabu.Optimizer` | Tabu-search local search. | `initial_states`, `initial_states_generator`, `num_reads`, `seed`, `tenure`, `timeout`, `num_restarts`, `energy_threshold`, `coefficient_z_first`, `coefficient_z_restart`, `lower_bound_z` |
 
 The upstream `planar` and `tree` samplers are not wrapped yet. `PlanarGraphSolver`
 only applies to planar Ising models without linear biases, and the tree

--- a/src/DWave.jl
+++ b/src/DWave.jl
@@ -81,6 +81,10 @@ function jl_object(py_obj)
 end
 
 include("sampler.jl")
+include("classical.jl")
 include("neal/sampler.jl")
+include("greedy/sampler.jl")
+include("random/sampler.jl")
+include("tabu/sampler.jl")
 
 end # module

--- a/src/classical.jl
+++ b/src/classical.jl
@@ -1,0 +1,199 @@
+"""
+Clear the cached `dwave.samplers` module tree before rebuilding a classical
+sampler import state.
+
+This mutates Python's `sys.modules` and should only be used during package
+initialization or in tests that need a clean import environment.
+"""
+function _clear_dwave_samplers_import_state!()
+    PythonCall.pyexec(
+        """
+for name in tuple(sys.modules):
+    if name == "dwave.samplers" or name.startswith("dwave.samplers."):
+        sys.modules.pop(name, None)
+
+if hasattr(dwave, "samplers"):
+    del dwave.samplers
+""",
+        @__MODULE__,
+        (
+            dwave = pyimport("dwave"),
+            sys = pyimport("sys"),
+        ),
+    )
+
+    return nothing
+end
+
+"""
+Import a target below `dwave.samplers` without executing
+`dwave.samplers.__init__`.
+
+When `leaf_is_package = true`, the target is treated as a package relative to
+`dwave.samplers`; otherwise the target is treated as a module path.
+"""
+function _import_dwave_samplers_target(target::String; leaf_is_package::Bool = false)
+    locals = (
+        dwave = pyimport("dwave"),
+        importlib = pyimport("importlib"),
+        pathlib = pyimport("pathlib"),
+        sys = pyimport("sys"),
+        target = target,
+        leaf_is_package = leaf_is_package,
+    )
+
+    ans = PythonCall.pyexec(
+        @NamedTuple{target_module::PythonCall.Py},
+        """
+root = next(iter(dwave.__path__), None)
+if root is None:
+    raise ImportError("dwave package does not define an import path")
+
+root = pathlib.Path(root)
+samplers_name = "dwave.samplers"
+samplers_dir = root / "samplers"
+
+samplers_spec = importlib.util.spec_from_file_location(
+    samplers_name,
+    samplers_dir / "__init__.py",
+    submodule_search_locations=[str(samplers_dir)],
+)
+samplers_pkg = importlib.util.module_from_spec(samplers_spec)
+sys.modules[samplers_name] = samplers_pkg
+dwave.samplers = samplers_pkg
+
+parts = target.split(".")
+parent_name = samplers_name
+parent_pkg = samplers_pkg
+parent_dir = samplers_dir
+
+for part in parts[:-1]:
+    parent_dir = parent_dir / part
+    pkg_name = f"{parent_name}.{part}"
+    pkg_spec = importlib.util.spec_from_file_location(
+        pkg_name,
+        parent_dir / "__init__.py",
+        submodule_search_locations=[str(parent_dir)],
+    )
+    pkg_mod = importlib.util.module_from_spec(pkg_spec)
+    sys.modules[pkg_name] = pkg_mod
+    setattr(parent_pkg, part, pkg_mod)
+    parent_pkg = pkg_mod
+    parent_name = pkg_name
+
+leaf = parts[-1]
+leaf_name = f"{parent_name}.{leaf}"
+
+if leaf_is_package:
+    leaf_dir = parent_dir / leaf
+    leaf_spec = importlib.util.spec_from_file_location(
+        leaf_name,
+        leaf_dir / "__init__.py",
+        submodule_search_locations=[str(leaf_dir)],
+    )
+    leaf_mod = importlib.util.module_from_spec(leaf_spec)
+    sys.modules[leaf_name] = leaf_mod
+    setattr(parent_pkg, leaf, leaf_mod)
+    leaf_spec.loader.exec_module(leaf_mod)
+else:
+    leaf_spec = importlib.util.spec_from_file_location(
+        leaf_name,
+        parent_dir / f"{leaf}.py",
+    )
+    leaf_mod = importlib.util.module_from_spec(leaf_spec)
+    sys.modules[leaf_name] = leaf_mod
+    setattr(parent_pkg, leaf, leaf_mod)
+    leaf_spec.loader.exec_module(leaf_mod)
+
+target_module = leaf_mod
+""",
+        @__MODULE__,
+        locals,
+    )
+
+    return ans.target_module
+end
+
+"""
+Initialize a classical `dwave.samplers` target in a `pynew()` slot.
+
+On Windows this falls back to Python's standard import machinery if the narrow
+import path fails, which is required for some compiled extensions.
+"""
+function _init_dwave_samplers_target!(
+    target_ref::PythonCall.Py,
+    import_mode::Base.RefValue{Symbol},
+    target::String;
+    leaf_is_package::Bool = false,
+)
+    _clear_dwave_samplers_import_state!()
+
+    try
+        PythonCall.pycopy!(target_ref, _import_dwave_samplers_target(target; leaf_is_package))
+        import_mode[] = :narrow
+    catch err
+        if Sys.iswindows()
+            _clear_dwave_samplers_import_state!()
+            PythonCall.pycopy!(target_ref, pyimport("dwave.samplers.$target"))
+            import_mode[] = :fallback
+        else
+            rethrow(err)
+        end
+    end
+
+    return nothing
+end
+
+function _normalize_initial_states(n::Int, initial_states)
+    if initial_states === nothing || initial_states isa PythonCall.Py
+        return initial_states
+    elseif initial_states isa AbstractVector
+        length(initial_states) == n || throw(
+            ArgumentError("`initial_states` must have length $n, got $(length(initial_states))"),
+        )
+
+        return Py((reshape(Int.(collect(initial_states)), 1, n), collect(0:(n - 1))))
+    elseif initial_states isa AbstractMatrix
+        size(initial_states, 2) == n || throw(
+            ArgumentError(
+                "`initial_states` must have $n columns, got $(size(initial_states, 2))",
+            ),
+        )
+
+        return Py((Int.(Matrix(initial_states)), collect(0:(n - 1))))
+    else
+        return Py(initial_states)
+    end
+end
+
+function _format_classical_sampleset(::Type{T}, results, n::Int, α, β; origin::String) where {T}
+    samples = QUBOTools.Sample{T,Int}[]
+    var_map = pyconvert.(Int, [var for var in results.value.variables]) .+ 1
+
+    for row in results.value.record
+        ψ = zeros(Int, n)
+
+        for (i, v) in enumerate(row["sample"])
+            ψ[var_map[i]] = pyconvert(Int, v)
+        end
+
+        push!(
+            samples,
+            QUBOTools.Sample{T,Int}(
+                ψ,
+                α * (pyconvert(T, row["energy"]) + β),
+                pyconvert(Int, row["num_occurrences"]),
+            ),
+        )
+    end
+
+    metadata = Dict{String,Any}(
+        "origin" => origin,
+        "time" => Dict{String,Any}(
+            "effective" => results.time,
+        ),
+        "dwave_info" => jl_object(results.value.info),
+    )
+
+    return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
+end

--- a/src/classical.jl
+++ b/src/classical.jl
@@ -1,6 +1,5 @@
 """
-Clear the cached `dwave.samplers` module tree before rebuilding a classical
-sampler import state.
+Clear the cached `dwave.samplers` module tree.
 
 This mutates Python's `sys.modules` and should only be used during package
 initialization or in tests that need a clean import environment.
@@ -19,6 +18,61 @@ if hasattr(dwave, "samplers"):
         (
             dwave = pyimport("dwave"),
             sys = pyimport("sys"),
+        ),
+    )
+
+    return nothing
+end
+
+function _dwave_samplers_import_name(target::String)
+    return "dwave.samplers.$target"
+end
+
+"""
+Clear only the cached subtree for a specific `dwave.samplers` target.
+
+This preserves unrelated sampler subtrees that were already imported through
+other wrappers.
+"""
+function _clear_dwave_samplers_import_target!(target::String)
+    PythonCall.pyexec(
+        """
+samplers_name = "dwave.samplers"
+target_name = target_import_name
+
+prefixes = {target_name}
+target_parts = target_name.split(".")[2:]
+for i in range(1, len(target_parts)):
+    prefixes.add(f"{samplers_name}." + ".".join(target_parts[:i]))
+
+names_to_remove = set()
+for module_name in tuple(sys.modules):
+    for prefix in prefixes:
+        if module_name == prefix or module_name.startswith(prefix + "."):
+            names_to_remove.add(module_name)
+            break
+
+for name in sorted(names_to_remove, key=lambda item: item.count("."), reverse=True):
+    mod = sys.modules.pop(name, None)
+    if mod is None:
+        continue
+
+    parent_name, _, child_name = name.rpartition(".")
+    if parent_name and parent_name in sys.modules:
+        parent_mod = sys.modules[parent_name]
+        if getattr(parent_mod, child_name, None) is mod:
+            delattr(parent_mod, child_name)
+
+if samplers_name in sys.modules:
+    dwave.samplers = sys.modules[samplers_name]
+elif hasattr(dwave, "samplers"):
+    del dwave.samplers
+""",
+        @__MODULE__,
+        (
+            dwave = pyimport("dwave"),
+            sys = pyimport("sys"),
+            target_import_name = _dwave_samplers_import_name(target),
         ),
     )
 
@@ -53,13 +107,46 @@ root = pathlib.Path(root)
 samplers_name = "dwave.samplers"
 samplers_dir = root / "samplers"
 
-samplers_spec = importlib.util.spec_from_file_location(
-    samplers_name,
-    samplers_dir / "__init__.py",
-    submodule_search_locations=[str(samplers_dir)],
-)
-samplers_pkg = importlib.util.module_from_spec(samplers_spec)
-sys.modules[samplers_name] = samplers_pkg
+def build_spec_or_raise(name, location, submodule_search_locations=None, importlib=importlib):
+    if not location.exists():
+        raise ImportError(f"Could not build module spec for {name} from {location}")
+    spec = importlib.util.spec_from_file_location(
+        name,
+        location,
+        submodule_search_locations=submodule_search_locations,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not build module spec for {name} from {location}")
+    return spec
+
+def ensure_package_stub(
+    name,
+    directory,
+    parent_pkg=None,
+    attr_name=None,
+    sys=sys,
+    importlib=importlib,
+    build_spec_or_raise=build_spec_or_raise,
+):
+    expected_path = [str(directory)]
+    pkg_mod = sys.modules.get(name)
+    if pkg_mod is None or list(getattr(pkg_mod, "__path__", [])) != expected_path:
+        pkg_spec = build_spec_or_raise(
+            name,
+            directory / "__init__.py",
+            submodule_search_locations=expected_path,
+        )
+        pkg_mod = importlib.util.module_from_spec(pkg_spec)
+        # Register a package stub with the real search path, but do not execute
+        # __init__ because that would eagerly import unrelated samplers.
+        sys.modules[name] = pkg_mod
+
+    if parent_pkg is not None and attr_name is not None:
+        setattr(parent_pkg, attr_name, pkg_mod)
+
+    return pkg_mod
+
+samplers_pkg = ensure_package_stub(samplers_name, samplers_dir)
 dwave.samplers = samplers_pkg
 
 parts = target.split(".")
@@ -70,14 +157,7 @@ parent_dir = samplers_dir
 for part in parts[:-1]:
     parent_dir = parent_dir / part
     pkg_name = f"{parent_name}.{part}"
-    pkg_spec = importlib.util.spec_from_file_location(
-        pkg_name,
-        parent_dir / "__init__.py",
-        submodule_search_locations=[str(parent_dir)],
-    )
-    pkg_mod = importlib.util.module_from_spec(pkg_spec)
-    sys.modules[pkg_name] = pkg_mod
-    setattr(parent_pkg, part, pkg_mod)
+    pkg_mod = ensure_package_stub(pkg_name, parent_dir, parent_pkg, part)
     parent_pkg = pkg_mod
     parent_name = pkg_name
 
@@ -86,7 +166,7 @@ leaf_name = f"{parent_name}.{leaf}"
 
 if leaf_is_package:
     leaf_dir = parent_dir / leaf
-    leaf_spec = importlib.util.spec_from_file_location(
+    leaf_spec = build_spec_or_raise(
         leaf_name,
         leaf_dir / "__init__.py",
         submodule_search_locations=[str(leaf_dir)],
@@ -96,7 +176,7 @@ if leaf_is_package:
     setattr(parent_pkg, leaf, leaf_mod)
     leaf_spec.loader.exec_module(leaf_mod)
 else:
-    leaf_spec = importlib.util.spec_from_file_location(
+    leaf_spec = build_spec_or_raise(
         leaf_name,
         parent_dir / f"{leaf}.py",
     )
@@ -126,15 +206,19 @@ function _init_dwave_samplers_target!(
     target::String;
     leaf_is_package::Bool = false,
 )
-    _clear_dwave_samplers_import_state!()
+    # Keep sibling sampler modules alive in sys.modules by clearing only the
+    # target subtree, prefer the narrow import path that avoids executing
+    # dwave.samplers.__init__, and only fall back to Python's standard import
+    # machinery on Windows when compiled extensions require it.
+    _clear_dwave_samplers_import_target!(target)
 
     try
         PythonCall.pycopy!(target_ref, _import_dwave_samplers_target(target; leaf_is_package))
         import_mode[] = :narrow
     catch err
         if Sys.iswindows()
-            _clear_dwave_samplers_import_state!()
-            PythonCall.pycopy!(target_ref, pyimport("dwave.samplers.$target"))
+            _clear_dwave_samplers_import_target!(target)
+            PythonCall.pycopy!(target_ref, pyimport(_dwave_samplers_import_name(target)))
             import_mode[] = :fallback
         else
             rethrow(err)
@@ -166,7 +250,15 @@ function _normalize_initial_states(n::Int, initial_states)
     end
 end
 
-function _format_classical_sampleset(::Type{T}, results, n::Int, α, β; origin::String) where {T}
+function _format_classical_sampleset(
+    ::Type{T},
+    results,
+    n::Int,
+    α,
+    β;
+    origin::String,
+    include_dwave_info::Bool = true,
+) where {T}
     samples = QUBOTools.Sample{T,Int}[]
     var_map = pyconvert.(Int, [var for var in results.value.variables]) .+ 1
 
@@ -192,8 +284,11 @@ function _format_classical_sampleset(::Type{T}, results, n::Int, α, β; origin:
         "time" => Dict{String,Any}(
             "effective" => results.time,
         ),
-        "dwave_info" => jl_object(results.value.info),
     )
+
+    if include_dwave_info
+        metadata["dwave_info"] = jl_object(results.value.info)
+    end
 
     return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
 end

--- a/src/classical.jl
+++ b/src/classical.jl
@@ -209,7 +209,9 @@ function _init_dwave_samplers_target!(
     # Keep sibling sampler modules alive in sys.modules by clearing only the
     # target subtree, prefer the narrow import path that avoids executing
     # dwave.samplers.__init__, and only fall back to Python's standard import
-    # machinery on Windows when compiled extensions require it.
+    # machinery on Windows when compiled extensions require it. That fallback
+    # must start from a fully clean dwave.samplers tree so Python can rebuild
+    # the real package hierarchy instead of reusing our synthetic root stub.
     _clear_dwave_samplers_import_target!(target)
 
     try
@@ -217,7 +219,7 @@ function _init_dwave_samplers_target!(
         import_mode[] = :narrow
     catch err
         if Sys.iswindows()
-            _clear_dwave_samplers_import_target!(target)
+            _clear_dwave_samplers_import_state!()
             PythonCall.pycopy!(target_ref, pyimport(_dwave_samplers_import_name(target)))
             import_mode[] = :fallback
         else

--- a/src/greedy/sampler.jl
+++ b/src/greedy/sampler.jl
@@ -29,6 +29,8 @@ QUBODrivers.@setup Optimizer begin
     name       = "D-Wave Greedy Steepest Descent Sampler"
     version    = v"8.4.0" # dwave-ocean-sdk version
     attributes = begin
+        # Delegate `nothing` to the upstream sampler, which infers num_reads
+        # from initial_states or defaults to a single read.
         "num_reads"::Union{Integer,Nothing} = nothing
         "initial_states"::Any = nothing
         "initial_states_generator"::String = "random"

--- a/src/greedy/sampler.jl
+++ b/src/greedy/sampler.jl
@@ -1,0 +1,62 @@
+module Greedy
+
+import ..DWave
+import QUBODrivers
+import QUBOTools
+import MathOptInterface as MOI
+
+using PythonCall
+
+const dwave_samplers = PythonCall.pynew()
+const dwave_samplers_import_mode = Ref{Symbol}(:uninitialized)
+
+function _clear_import_state!()
+    return DWave._clear_dwave_samplers_import_state!()
+end
+
+function __init__()
+    DWave._init_dwave_samplers_target!(dwave_samplers, dwave_samplers_import_mode, "greedy.sampler")
+
+    return nothing
+end
+
+@doc raw"""
+    DWave.Greedy.Optimizer
+
+D-Wave's steepest-descent sampler for QUBO and Ising models.
+"""
+QUBODrivers.@setup Optimizer begin
+    name       = "D-Wave Greedy Steepest Descent Sampler"
+    version    = v"8.4.0" # dwave-ocean-sdk version
+    attributes = begin
+        "num_reads"::Union{Integer,Nothing} = nothing
+        "initial_states"::Any = nothing
+        "initial_states_generator"::String = "random"
+        "seed"::Union{Integer,Nothing} = nothing
+        "large_sparse_opt"::Bool = false
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
+
+    params = Dict{Symbol,Any}(
+        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
+        :initial_states => DWave._normalize_initial_states(
+            n,
+            MOI.get(sampler, MOI.RawOptimizerAttribute("initial_states")),
+        ),
+        :initial_states_generator => MOI.get(
+            sampler,
+            MOI.RawOptimizerAttribute("initial_states_generator"),
+        ),
+        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
+        :large_sparse_opt => MOI.get(sampler, MOI.RawOptimizerAttribute("large_sparse_opt")),
+    )
+
+    results = @timed dwave_samplers.SteepestDescentSampler().sample_ising(Py(h), Py(J); params...)
+
+    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Greedy")
+end
+
+end # module Greedy

--- a/src/neal/sampler.jl
+++ b/src/neal/sampler.jl
@@ -68,10 +68,18 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         :interrupt_function => MOI.get(sampler, MOI.RawOptimizerAttribute("interrupt_function")),
     )
 
-    sampler = dwave_samplers.SimulatedAnnealingSampler()
-    results = @timed sampler.sample_ising(Py(h), Py(J); params...)
+    py_sampler = dwave_samplers.SimulatedAnnealingSampler()
+    results = @timed py_sampler.sample_ising(Py(h), Py(J); params...)
 
-    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Neal")
+    return DWave._format_classical_sampleset(
+        T,
+        results,
+        n,
+        α,
+        β;
+        origin = "D-Wave Neal",
+        include_dwave_info = false,
+    )
 end
 
 end # module Neal

--- a/src/neal/sampler.jl
+++ b/src/neal/sampler.jl
@@ -1,5 +1,6 @@
 module Neal
 
+import ..DWave
 import QUBODrivers
 import QUBOTools
 import MathOptInterface as MOI
@@ -20,118 +21,13 @@ Tracks how `dwave_samplers` was initialized.
 """
 const dwave_samplers_import_mode = Ref{Symbol}(:uninitialized)
 
-"""
-Clear the cached `dwave.samplers` module tree before rebuilding the Neal import state.
-
-This mutates Python's `sys.modules` and should only be used during package
-initialization or in tests that need a clean import environment.
-"""
 function _clear_sa_import_state!()
-    PythonCall.pyexec(
-        """
-for name in tuple(sys.modules):
-    if name == "dwave.samplers" or name.startswith("dwave.samplers."):
-        sys.modules.pop(name, None)
-
-if hasattr(dwave, "samplers"):
-    del dwave.samplers
-""",
-        @__MODULE__,
-        (
-            dwave = pyimport("dwave"),
-            sys = pyimport("sys"),
-        ),
-    )
-
-    return nothing
-end
-
-function _import_sa_sampler()
-    locals = (
-        dwave = pyimport("dwave"),
-        importlib = pyimport("importlib"),
-        pathlib = pyimport("pathlib"),
-        sys = pyimport("sys"),
-    )
-
-    ans = PythonCall.pyexec(
-        @NamedTuple{sampler::PythonCall.Py},
-        """
-root = next(iter(dwave.__path__), None)
-if root is None:
-    raise ImportError("dwave package does not define an import path")
-
-root = pathlib.Path(root)
-samplers_name = "dwave.samplers"
-sa_name = "dwave.samplers.sa"
-sampler_name = "dwave.samplers.sa.sampler"
-samplers_dir = root / "samplers"
-sa_dir = samplers_dir / "sa"
-
-samplers_spec = importlib.util.spec_from_file_location(
-    samplers_name,
-    samplers_dir / "__init__.py",
-    submodule_search_locations=[str(samplers_dir)],
-)
-samplers_pkg = importlib.util.module_from_spec(samplers_spec)
-# Keep the real package search path, but do not execute __init__ because that
-# eagerly imports unrelated samplers such as dwave.samplers.random.
-sys.modules[samplers_name] = samplers_pkg
-
-dwave.samplers = samplers_pkg
-
-sa_spec = importlib.util.spec_from_file_location(
-    sa_name,
-    sa_dir / "__init__.py",
-    submodule_search_locations=[str(sa_dir)],
-)
-sa_pkg = importlib.util.module_from_spec(sa_spec)
-# As above, keep a valid package object for submodule resolution without running
-# dwave.samplers.sa.__init__.
-sys.modules[sa_name] = sa_pkg
-
-samplers_pkg.sa = sa_pkg
-
-spec = importlib.util.spec_from_file_location(
-    sampler_name,
-    sa_dir / "sampler.py",
-)
-sampler = importlib.util.module_from_spec(spec)
-sys.modules[sampler_name] = sampler
-spec.loader.exec_module(sampler)
-
-sa_pkg.sampler = sampler
-""",
-        @__MODULE__,
-        locals,
-    )
-
-    return ans.sampler
+    return DWave._clear_dwave_samplers_import_state!()
 end
 
 function __init__()
     PythonCall.pycopy!(np, pyimport("numpy"))
-    # Note: 'neal' package was deprecated and replaced by 'dwave.samplers' in
-    # dwave-ocean-sdk 8.0+. Load the simulated annealing submodule directly so
-    # we do not execute dwave.samplers.__init__ and pull in unrelated samplers.
-    # Rebuild the package tree from a clean Python import state so repeated
-    # initialization and partially imported modules do not leak into the wrapper.
-    _clear_sa_import_state!()
-
-    try
-        PythonCall.pycopy!(dwave_samplers, _import_sa_sampler())
-        dwave_samplers_import_mode[] = :narrow
-    catch err
-        if Sys.iswindows()
-            # Windows still needs Python's standard package import machinery for
-            # the compiled simulated_annealing extension to resolve its DLLs.
-            _clear_sa_import_state!()
-            PythonCall.pycopy!(dwave_samplers, pyimport("dwave.samplers.sa.sampler"))
-            dwave_samplers_import_mode[] = :fallback
-        else
-            rethrow(err)
-        end
-    end
+    DWave._init_dwave_samplers_target!(dwave_samplers, dwave_samplers_import_mode, "sa.sampler")
 
     return nothing
 end
@@ -158,10 +54,8 @@ QUBODrivers.@setup Optimizer begin
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
-    # Retrieve Ising Model
     n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
 
-    # Retrieve Optimizer Attributes
     params = Dict{Symbol,Any}(
         :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
         :num_sweeps => MOI.get(sampler, MOI.RawOptimizerAttribute("num_sweeps")),
@@ -174,48 +68,10 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         :interrupt_function => MOI.get(sampler, MOI.RawOptimizerAttribute("interrupt_function")),
     )
 
-    # Call D-Wave Neal API
     sampler = dwave_samplers.SimulatedAnnealingSampler()
     results = @timed sampler.sample_ising(Py(h), Py(J); params...)
 
-    # Format Samples
-    samples = QUBOTools.Sample{T,Int}[]
-    # NumPy-array Ising inputs label variables 0:(n-1) on the Python side.
-    var_map = pyconvert.(Int, [var for var in results.value.variables]) .+ 1
-
-    for (ϕ, λ, r) in results.value.record
-        # the dwave sampler will not consider variables that are not
-        # present in the objective funcion, leading to holes with
-        # respect to the indices in the record table.
-        # Therefore, it is necessary to introduce an extra layer of
-        # indirection to account for the missing variables.
-        ψ = zeros(Int, n)
-
-        for (i, v) in enumerate(ϕ)
-            ψ[var_map[i]] = pyconvert(Int, v)
-        end
-
-        sample = QUBOTools.Sample{T,Int}(
-            # state:
-            ψ,
-            # energy:
-            α * (pyconvert(T, λ) + β),
-            # reads:
-            pyconvert(Int, r),
-        )
-
-        push!(samples, sample)
-    end
-
-    # Write metadata
-    metadata = Dict{String,Any}(
-        "origin" => "D-Wave Neal",
-        "time"   => Dict{String,Any}( #
-            "effective" => results.time
-        ),
-    )
-
-    return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
+    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Neal")
 end
 
 end # module Neal

--- a/src/random/sampler.jl
+++ b/src/random/sampler.jl
@@ -1,0 +1,54 @@
+module Random
+
+import ..DWave
+import QUBODrivers
+import QUBOTools
+import MathOptInterface as MOI
+
+using PythonCall
+
+const dwave_samplers = PythonCall.pynew()
+const dwave_samplers_import_mode = Ref{Symbol}(:uninitialized)
+
+function _clear_import_state!()
+    return DWave._clear_dwave_samplers_import_state!()
+end
+
+function __init__()
+    DWave._init_dwave_samplers_target!(dwave_samplers, dwave_samplers_import_mode, "random.sampler")
+
+    return nothing
+end
+
+@doc raw"""
+    DWave.Random.Optimizer
+
+D-Wave's random sampler for QUBO and Ising models.
+"""
+QUBODrivers.@setup Optimizer begin
+    name       = "D-Wave Random Sampler"
+    version    = v"8.4.0" # dwave-ocean-sdk version
+    attributes = begin
+        "num_reads"::Union{Integer,Nothing} = nothing
+        "time_limit"::Any = nothing
+        "max_num_samples"::Integer = 1_000
+        "seed"::Any = nothing
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
+
+    params = Dict{Symbol,Any}(
+        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
+        :time_limit => MOI.get(sampler, MOI.RawOptimizerAttribute("time_limit")),
+        :max_num_samples => MOI.get(sampler, MOI.RawOptimizerAttribute("max_num_samples")),
+        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
+    )
+
+    results = @timed dwave_samplers.RandomSampler().sample_ising(Py(h), Py(J); params...)
+
+    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Random")
+end
+
+end # module Random

--- a/src/random/sampler.jl
+++ b/src/random/sampler.jl
@@ -30,9 +30,9 @@ QUBODrivers.@setup Optimizer begin
     version    = v"8.4.0" # dwave-ocean-sdk version
     attributes = begin
         "num_reads"::Union{Integer,Nothing} = nothing
-        "time_limit"::Any = nothing
+        "time_limit"::Union{Real,Nothing} = nothing
         "max_num_samples"::Integer = 1_000
-        "seed"::Any = nothing
+        "seed"::Union{Integer,Nothing} = nothing
     end
 end
 

--- a/src/tabu/sampler.jl
+++ b/src/tabu/sampler.jl
@@ -19,6 +19,8 @@ function __init__()
         dwave_samplers,
         dwave_samplers_import_mode,
         "tabu";
+        # TabuSampler is re-exported from dwave.samplers.tabu.__init__, so this
+        # wrapper needs the package-level import rather than sampler.py alone.
         leaf_is_package = true,
     )
 

--- a/src/tabu/sampler.jl
+++ b/src/tabu/sampler.jl
@@ -1,0 +1,85 @@
+module Tabu
+
+import ..DWave
+import QUBODrivers
+import QUBOTools
+import MathOptInterface as MOI
+
+using PythonCall
+
+const dwave_samplers = PythonCall.pynew()
+const dwave_samplers_import_mode = Ref{Symbol}(:uninitialized)
+
+function _clear_import_state!()
+    return DWave._clear_dwave_samplers_import_state!()
+end
+
+function __init__()
+    DWave._init_dwave_samplers_target!(
+        dwave_samplers,
+        dwave_samplers_import_mode,
+        "tabu";
+        leaf_is_package = true,
+    )
+
+    return nothing
+end
+
+@doc raw"""
+    DWave.Tabu.Optimizer
+
+D-Wave's tabu-search sampler for QUBO and Ising models.
+"""
+QUBODrivers.@setup Optimizer begin
+    name       = "D-Wave Tabu Sampler"
+    version    = v"8.4.0" # dwave-ocean-sdk version
+    attributes = begin
+        "initial_states"::Any = nothing
+        "initial_states_generator"::String = "random"
+        "num_reads"::Union{Integer,Nothing} = nothing
+        "seed"::Union{Integer,Nothing} = nothing
+        "tenure"::Union{Integer,Nothing} = nothing
+        "timeout"::Union{Integer,Nothing} = 20
+        "num_restarts"::Integer = 1_000_000
+        "energy_threshold"::Any = nothing
+        "coefficient_z_first"::Union{Integer,Nothing} = nothing
+        "coefficient_z_restart"::Union{Integer,Nothing} = nothing
+        "lower_bound_z"::Union{Integer,Nothing} = nothing
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
+
+    params = Dict{Symbol,Any}(
+        :initial_states => DWave._normalize_initial_states(
+            n,
+            MOI.get(sampler, MOI.RawOptimizerAttribute("initial_states")),
+        ),
+        :initial_states_generator => MOI.get(
+            sampler,
+            MOI.RawOptimizerAttribute("initial_states_generator"),
+        ),
+        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
+        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
+        :tenure => MOI.get(sampler, MOI.RawOptimizerAttribute("tenure")),
+        :timeout => MOI.get(sampler, MOI.RawOptimizerAttribute("timeout")),
+        :num_restarts => MOI.get(sampler, MOI.RawOptimizerAttribute("num_restarts")),
+        :energy_threshold => MOI.get(sampler, MOI.RawOptimizerAttribute("energy_threshold")),
+        :coefficient_z_first => MOI.get(
+            sampler,
+            MOI.RawOptimizerAttribute("coefficient_z_first"),
+        ),
+        :coefficient_z_restart => MOI.get(
+            sampler,
+            MOI.RawOptimizerAttribute("coefficient_z_restart"),
+        ),
+        :lower_bound_z => MOI.get(sampler, MOI.RawOptimizerAttribute("lower_bound_z")),
+    )
+
+    results = @timed dwave_samplers.TabuSampler().sample_ising(Py(h), Py(J); params...)
+
+    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Tabu")
+end
+
+end # module Tabu

--- a/test/classical_parity.jl
+++ b/test/classical_parity.jl
@@ -1,0 +1,320 @@
+import DWave
+import QUBODrivers
+import QUBOTools
+import Random
+import Test
+
+const MOI = QUBODrivers.MOI
+const ClassicalRecord = NamedTuple{(:energy, :reads, :state),Tuple{Float64,Int,Tuple{Vararg{Int}}}}
+
+const CLASSICAL_SPECS = (
+    (
+        name = "Greedy",
+        sampler_module = DWave.Greedy,
+        optimizer = DWave.Greedy.Optimizer,
+        constructor = :SteepestDescentSampler,
+        module_name = "dwave.samplers.greedy.sampler",
+        present_modules = (
+            "dwave.samplers",
+            "dwave.samplers.greedy",
+            "dwave.samplers.greedy.sampler",
+            "dwave.samplers.greedy.descent",
+        ),
+        absent_modules = (
+            "dwave.samplers.random",
+            "dwave.samplers.sa",
+            "dwave.samplers.tabu",
+        ),
+    ),
+    (
+        name = "Random",
+        sampler_module = DWave.Random,
+        optimizer = DWave.Random.Optimizer,
+        constructor = :RandomSampler,
+        module_name = "dwave.samplers.random.sampler",
+        present_modules = (
+            "dwave.samplers",
+            "dwave.samplers.random",
+            "dwave.samplers.random.sampler",
+            "dwave.samplers.random.cyrandom",
+        ),
+        absent_modules = (
+            "dwave.samplers.greedy",
+            "dwave.samplers.sa",
+            "dwave.samplers.tabu",
+        ),
+    ),
+    (
+        name = "Tabu",
+        sampler_module = DWave.Tabu,
+        optimizer = DWave.Tabu.Optimizer,
+        constructor = :TabuSampler,
+        module_name = "dwave.samplers.tabu",
+        present_modules = (
+            "dwave.samplers",
+            "dwave.samplers.tabu",
+            "dwave.samplers.tabu.sampler",
+            "dwave.samplers.tabu.tabu_search",
+        ),
+        absent_modules = (
+            "dwave.samplers.greedy",
+            "dwave.samplers.random",
+            "dwave.samplers.sa",
+        ),
+    ),
+)
+
+function _classical_random_ising_instance(n::Int, seed::Int)
+    rng = Random.MersenneTwister(seed)
+
+    h = randn(rng, n)
+    J = zeros(Float64, n, n)
+
+    for i in 1:n, j in (i + 1):n
+        J[i, j] = randn(rng)
+    end
+
+    return h, J
+end
+
+function _classical_aggregate_records(records::Vector{ClassicalRecord})
+    aggregated = Dict{Tuple{Float64,Tuple},Int}()
+
+    for record in records
+        key = (record.energy, record.state)
+        aggregated[key] = get(aggregated, key, 0) + record.reads
+    end
+
+    normalized = ClassicalRecord[]
+
+    for ((energy, state), reads) in aggregated
+        push!(normalized, (energy = energy, reads = reads, state = state))
+    end
+
+    sort!(normalized; by = r -> (r.energy, r.reads, r.state))
+
+    return normalized
+end
+
+function _direct_records(spec, h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    results = getproperty(spec.sampler_module.dwave_samplers, spec.constructor)().sample_ising(
+        spec.sampler_module.PythonCall.Py(h),
+        spec.sampler_module.PythonCall.Py(J);
+        kwargs...,
+    )
+
+    n = length(h)
+    var_map = spec.sampler_module.PythonCall.pyconvert.(Int, [var for var in results.variables]) .+ 1
+    records = ClassicalRecord[]
+
+    for row in results.record
+        ψ = zeros(Int, n)
+
+        for (i, v) in enumerate(row["sample"])
+            ψ[var_map[i]] = spec.sampler_module.PythonCall.pyconvert(Int, v)
+        end
+
+        push!(
+            records,
+            (
+                energy = spec.sampler_module.PythonCall.pyconvert(Float64, row["energy"]),
+                reads = spec.sampler_module.PythonCall.pyconvert(Int, row["num_occurrences"]),
+                state = Tuple(ψ),
+            ),
+        )
+    end
+
+    sort!(records; by = r -> (r.energy, r.reads, r.state))
+
+    return records
+end
+
+function _wrapper_model(optimizer, h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    n = length(h)
+    model = MOI.instantiate(optimizer; with_bridge_type = Float64)
+    s, _ = MOI.add_constrained_variables(model, fill(QUBODrivers.Spin(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarQuadraticTerm{Float64}[
+                MOI.ScalarQuadraticTerm{Float64}(J[i, j], s[i], s[j]) for i in 1:n for j in (i + 1):n
+            ],
+            MOI.ScalarAffineTerm{Float64}[MOI.ScalarAffineTerm{Float64}(h[i], s[i]) for i in 1:n],
+            0.0,
+        ),
+    )
+
+    for (name, value) in pairs(kwargs)
+        MOI.set(model, MOI.RawOptimizerAttribute(String(name)), value)
+    end
+
+    return model, s
+end
+
+function _wrapper_records(optimizer, h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    model, s = _wrapper_model(optimizer, h, J; kwargs...)
+    QUBOTools_MOI = Base.get_extension(QUBOTools, :QUBOTools_MOI)
+
+    @assert !isnothing(QUBOTools_MOI)
+
+    MOI.optimize!(model)
+
+    records = ClassicalRecord[]
+
+    for i in 1:MOI.get(model, MOI.ResultCount())
+        push!(
+            records,
+            (
+                energy = MOI.get(model, MOI.ObjectiveValue(i)),
+                reads = MOI.get(model, QUBOTools_MOI.NumberOfReads(i)),
+                state = Tuple(Int(round(MOI.get(model, MOI.VariablePrimal(i), v))) for v in s),
+            ),
+        )
+    end
+
+    sort!(records; by = r -> (r.energy, r.reads, r.state))
+
+    return records
+end
+
+function _classical_sys_modules_contains(name::String)
+    sys = DWave.Neal.PythonCall.pyimport("sys")
+    return DWave.Neal.PythonCall.pyconvert(Bool, sys.modules.__contains__(name))
+end
+
+for spec in CLASSICAL_SPECS
+    Test.@testset "$(spec.name) initialization isolates the sampler import tree" begin
+        DWave._clear_dwave_samplers_import_state!()
+        spec.sampler_module.__init__()
+
+        Test.@test spec.sampler_module.PythonCall.pyconvert(
+            String,
+            spec.sampler_module.dwave_samplers.__name__,
+        ) ==
+            spec.module_name
+
+        for module_name in spec.present_modules
+            Test.@test _classical_sys_modules_contains(module_name)
+        end
+
+        if Sys.iswindows()
+            Test.@test spec.sampler_module.dwave_samplers_import_mode[] in (:narrow, :fallback)
+        else
+            Test.@test spec.sampler_module.dwave_samplers_import_mode[] == :narrow
+
+            for module_name in spec.absent_modules
+                Test.@test !_classical_sys_modules_contains(module_name)
+            end
+        end
+    end
+end
+
+Test.@testset "Greedy parity with direct dwave.samplers" begin
+    h, J = _classical_random_ising_instance(64, 17)
+    kwargs = (
+        num_reads = 96,
+        seed = 202_603_28,
+        large_sparse_opt = true,
+    )
+
+    direct_records = _classical_aggregate_records(_direct_records(CLASSICAL_SPECS[1], h, J; kwargs...))
+    wrapper_records = _classical_aggregate_records(
+        _wrapper_records(DWave.Greedy.Optimizer, h, J; kwargs...),
+    )
+
+    Test.@test wrapper_records == direct_records
+end
+
+Test.@testset "Greedy wrapper forwards initial states" begin
+    h = [0.0, 0.0]
+    J = zeros(Float64, 2, 2)
+    J[1, 2] = 1.0
+
+    kwargs = (
+        initial_states = [-1 -1],
+        initial_states_generator = "tile",
+        num_reads = 6,
+        seed = 91,
+    )
+
+    direct_records = _classical_aggregate_records(_direct_records(CLASSICAL_SPECS[1], h, J; kwargs...))
+    wrapper_records = _classical_aggregate_records(
+        _wrapper_records(DWave.Greedy.Optimizer, h, J; kwargs...),
+    )
+
+    Test.@test wrapper_records == direct_records
+end
+
+Test.@testset "Random parity with direct dwave.samplers" begin
+    h, J = _classical_random_ising_instance(20, 29)
+    kwargs = (
+        num_reads = 80,
+        seed = 202_603_29,
+        max_num_samples = 16,
+    )
+
+    direct_records = _classical_aggregate_records(_direct_records(CLASSICAL_SPECS[2], h, J; kwargs...))
+    wrapper_records = _classical_aggregate_records(
+        _wrapper_records(DWave.Random.Optimizer, h, J; kwargs...),
+    )
+
+    Test.@test wrapper_records == direct_records
+    Test.@test sum(record.reads for record in wrapper_records) == kwargs.num_reads
+end
+
+Test.@testset "Random wrapper seed determinism" begin
+    h, J = _classical_random_ising_instance(24, 37)
+    kwargs = (
+        num_reads = 48,
+        seed = 202_603_30,
+    )
+
+    records_a = _classical_aggregate_records(_wrapper_records(DWave.Random.Optimizer, h, J; kwargs...))
+    records_b = _classical_aggregate_records(_wrapper_records(DWave.Random.Optimizer, h, J; kwargs...))
+
+    Test.@test records_a == records_b
+end
+
+Test.@testset "Tabu parity with direct dwave.samplers" begin
+    h, J = _classical_random_ising_instance(18, 43)
+    kwargs = (
+        num_reads = 24,
+        seed = 202_603_31,
+        timeout = nothing,
+        num_restarts = 2,
+    )
+
+    direct_records = _classical_aggregate_records(_direct_records(CLASSICAL_SPECS[3], h, J; kwargs...))
+    wrapper_records = _classical_aggregate_records(
+        _wrapper_records(DWave.Tabu.Optimizer, h, J; kwargs...),
+    )
+
+    Test.@test wrapper_records == direct_records
+end
+
+Test.@testset "Tabu wrapper forwards initial states" begin
+    h = [0.0, 0.0, 0.0]
+    J = zeros(Float64, 3, 3)
+    J[1, 2] = -1.0
+    J[1, 3] = 1.0
+    J[2, 3] = 1.0
+
+    kwargs = (
+        initial_states = [1 1 1; -1 -1 -1],
+        initial_states_generator = "tile",
+        num_reads = 5,
+        seed = 123,
+        timeout = nothing,
+        num_restarts = 0,
+    )
+
+    direct_records = _classical_aggregate_records(_direct_records(CLASSICAL_SPECS[3], h, J; kwargs...))
+    wrapper_records = _classical_aggregate_records(
+        _wrapper_records(DWave.Tabu.Optimizer, h, J; kwargs...),
+    )
+
+    Test.@test wrapper_records == direct_records
+end

--- a/test/classical_parity.jl
+++ b/test/classical_parity.jl
@@ -7,6 +7,10 @@ import Test
 const MOI = QUBODrivers.MOI
 const ClassicalRecord = NamedTuple{(:energy, :reads, :state),Tuple{Float64,Int,Tuple{Vararg{Int}}}}
 
+# These presence checks intentionally cover the dwave-samplers 8.4.0 internal
+# imports exercised by each target. Greedy reaches `descent` as a side effect of
+# importing `greedy/sampler.py`, and Random must load `cyrandom`, the compiled
+# extension whose import compatibility caused issue #9.
 const CLASSICAL_SPECS = (
     (
         name = "Greedy",
@@ -14,6 +18,7 @@ const CLASSICAL_SPECS = (
         optimizer = DWave.Greedy.Optimizer,
         constructor = :SteepestDescentSampler,
         module_name = "dwave.samplers.greedy.sampler",
+        fallback_import_name = DWave._dwave_samplers_import_name("greedy.sampler"),
         present_modules = (
             "dwave.samplers",
             "dwave.samplers.greedy",
@@ -32,6 +37,7 @@ const CLASSICAL_SPECS = (
         optimizer = DWave.Random.Optimizer,
         constructor = :RandomSampler,
         module_name = "dwave.samplers.random.sampler",
+        fallback_import_name = DWave._dwave_samplers_import_name("random.sampler"),
         present_modules = (
             "dwave.samplers",
             "dwave.samplers.random",
@@ -50,6 +56,7 @@ const CLASSICAL_SPECS = (
         optimizer = DWave.Tabu.Optimizer,
         constructor = :TabuSampler,
         module_name = "dwave.samplers.tabu",
+        fallback_import_name = DWave._dwave_samplers_import_name("tabu"),
         present_modules = (
             "dwave.samplers",
             "dwave.samplers.tabu",
@@ -185,6 +192,27 @@ function _classical_sys_modules_contains(name::String)
     return DWave.Neal.PythonCall.pyconvert(Bool, sys.modules.__contains__(name))
 end
 
+function _assert_classical_direct_sampler_works(spec)
+    h = [0.0, -1.0, 0.25]
+    J = zeros(Float64, 3, 3)
+    J[1, 2] = -1.0
+    J[2, 3] = 0.5
+
+    kwargs = if spec.name == "Tabu"
+        (; num_reads = 1, seed = 11, timeout = nothing, num_restarts = 0)
+    else
+        (; num_reads = 1, seed = 11)
+    end
+
+    records = _direct_records(spec, h, J; kwargs...)
+
+    Test.@test length(records) == 1
+    Test.@test isfinite(only(records).energy)
+    Test.@test all(abs.(collect(only(records).state)) .== 1)
+
+    return nothing
+end
+
 for spec in CLASSICAL_SPECS
     Test.@testset "$(spec.name) initialization isolates the sampler import tree" begin
         DWave._clear_dwave_samplers_import_state!()
@@ -209,6 +237,61 @@ for spec in CLASSICAL_SPECS
                 Test.@test !_classical_sys_modules_contains(module_name)
             end
         end
+    end
+end
+
+Test.@testset "Classical fallback import names resolve through Python import machinery" begin
+    for import_name in (
+        DWave._dwave_samplers_import_name("sa.sampler"),
+        CLASSICAL_SPECS[1].fallback_import_name,
+        CLASSICAL_SPECS[2].fallback_import_name,
+        CLASSICAL_SPECS[3].fallback_import_name,
+    )
+        DWave._clear_dwave_samplers_import_state!()
+        imported = DWave.Neal.PythonCall.pyimport(import_name)
+
+        Test.@test DWave.Neal.PythonCall.pyconvert(String, imported.__name__) == import_name
+    end
+end
+
+Test.@testset "Invalid classical import targets report ImportError clearly" begin
+    DWave._clear_dwave_samplers_import_state!()
+
+    err = try
+        DWave._import_dwave_samplers_target("missing.sampler")
+        nothing
+    catch caught
+        caught
+    end
+
+    Test.@test err isa DWave.Neal.PythonCall.PyException
+    Test.@test occursin("Could not build module spec", err === nothing ? "" : sprint(showerror, err))
+end
+
+Test.@testset "Classical sampler references survive full initialization" begin
+    DWave._clear_dwave_samplers_import_state!()
+    DWave.Neal.__init__()
+
+    for spec in CLASSICAL_SPECS
+        spec.sampler_module.__init__()
+    end
+
+    for module_name in (
+        "dwave.samplers.sa",
+        "dwave.samplers.sa.sampler",
+        "dwave.samplers.greedy",
+        "dwave.samplers.greedy.sampler",
+        "dwave.samplers.random",
+        "dwave.samplers.random.sampler",
+        "dwave.samplers.tabu",
+    )
+        Test.@test _classical_sys_modules_contains(module_name)
+    end
+
+    _assert_neal_sampler_works()
+
+    for spec in CLASSICAL_SPECS
+        _assert_classical_direct_sampler_works(spec)
     end
 end
 

--- a/test/neal_parity.jl
+++ b/test/neal_parity.jl
@@ -124,6 +124,12 @@ function _wrapper_neal_records(h::Vector{Float64}, J::Matrix{Float64}; kwargs...
     return records
 end
 
+function _wrapper_neal_sampleset(h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
+    model, _ = _wrapper_neal_model(h, J; kwargs...)
+    MOI.optimize!(model)
+    return QUBOTools.solution(MOI.get(model, MOI.RawSolver()))
+end
+
 function _wrapper_neal_error(h::Vector{Float64}, J::Matrix{Float64}; kwargs...)
     model, _ = _wrapper_neal_model(h, J; kwargs...)
 
@@ -314,4 +320,17 @@ Test.@testset "Neal parity with sparse support" begin
 
     Test.@test wrapper_records == direct_records
     Test.@test all(all(abs.(record.state) .== 1) for record in wrapper_records)
+end
+
+Test.@testset "Neal metadata remains backward compatible" begin
+    h = [0.0, -1.0]
+    J = zeros(Float64, 2, 2)
+    J[1, 2] = -1.0
+
+    sampleset = _wrapper_neal_sampleset(h, J; num_reads = 4, num_sweeps = 10, seed = 7)
+    metadata = QUBOTools.metadata(sampleset)
+
+    Test.@test haskey(metadata, "origin")
+    Test.@test haskey(metadata, "time")
+    Test.@test !haskey(metadata, "dwave_info")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,9 @@ else
 end
 
 QUBODrivers.test(DWave.Neal.Optimizer; examples = true)
+QUBODrivers.test(DWave.Greedy.Optimizer; examples = true)
+QUBODrivers.test(DWave.Random.Optimizer; examples = true)
+QUBODrivers.test(DWave.Tabu.Optimizer; examples = true)
 
 include("neal_parity.jl")
+include("classical_parity.jl")


### PR DESCRIPTION
## Summary
Adds Julia wrappers for the additional `dwave-samplers` classical samplers that map cleanly onto the current `QUBODrivers` interface.

Closes #17.

## What changed
- added shared `dwave.samplers` import helpers so classical wrappers can load narrow sampler modules without executing `dwave.samplers.__init__`
- refactored `DWave.Neal` to use the shared import and sample-formatting path
- added `DWave.Greedy.Optimizer`, `DWave.Random.Optimizer`, and `DWave.Tabu.Optimizer`
- exposed the upstream sampler parameters that fit `RawOptimizerAttribute`, including `initial_states` support for greedy and tabu
- added parity and import-isolation tests for the new wrappers
- documented the new classical wrappers and the current omission of `planar` and `tree`

## Why
`DWave.jl` already wrapped Neal, but the other classical samplers in `dwave-samplers` were still unavailable from Julia. This adds the samplers that share the same BQM-style interface and avoids reintroducing the broad parent-package import path that previously caused problems in the classical import layer.

## Notes
`planar` and `tree` are intentionally left out of this PR. `PlanarGraphSolver` only supports planar Ising models without linear biases, and the tree decomposition samplers expose exact-solver and marginal APIs that do not fit the current `QUBODrivers` surface cleanly.

## Validation
- `JULIA_DEPOT_PATH=$PWD/.julia-depot:$HOME/.julia julia --project=. -e 'using Pkg; Pkg.test()'`
- verified direct parity against upstream Python samplers for greedy, random, and tabu
- verified isolated import behavior for each classical wrapper
