### PR TITLE
Document DWaveNeal migration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ julia> Pkg.add("DWave")
 ```
 
 ## Migration from DWaveNeal.jl
-`DWaveNeal.jl` is deprecated and kept only as a compatibility shim. New code
-should use `DWave.jl` directly:
+`DWaveNeal.jl` only covered the simulated annealing wrapper that now lives at
+`DWave.Neal.Optimizer` inside `DWave.jl`. The rest of `DWave.jl` provides
+additional samplers and is not part of the old `DWaveNeal.jl` API surface.
+
+For code that used `DWaveNeal.Optimizer`, install `DWave.jl` and switch to
+`DWave.Neal.Optimizer`:
 
 ```julia
 julia> import Pkg

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ julia> import Pkg
 julia> Pkg.add("DWave")
 ```
 
+## Migration from DWaveNeal.jl
+`DWaveNeal.jl` is deprecated and kept only as a compatibility shim. New code
+should use `DWave.jl` directly:
+
+```julia
+julia> import Pkg
+
+julia> Pkg.add("DWave")
+
+julia> using DWave
+```
+
+If you still have an environment that depends on `DWaveNeal`, `Pkg.add("DWaveNeal")`
+continues to work, but `DWaveNeal.Optimizer` now aliases
+`DWave.Neal.Optimizer` and emits a deprecation warning on load.
+
 ## Basic Usage
 ```julia
 using JuMP


### PR DESCRIPTION
## Summary
- add a README migration note for users still on DWaveNeal.jl
- document that DWaveNeal.jl is deprecated and kept as a compatibility shim
- point new users to DWave.jl and DWave.Neal.Optimizer

## Testing
- not run (documentation-only change)