### PR TITLE
Fix importlib.util narrow import for PythonCall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/src/classical.jl
+++ b/src/classical.jl
@@ -89,7 +89,7 @@ When `leaf_is_package = true`, the target is treated as a package relative to
 function _import_dwave_samplers_target(target::String; leaf_is_package::Bool = false)
     locals = (
         dwave = pyimport("dwave"),
-        importlib = pyimport("importlib"),
+        importlib_util = pyimport("importlib.util"),
         pathlib = pyimport("pathlib"),
         sys = pyimport("sys"),
         target = target,
@@ -107,10 +107,10 @@ root = pathlib.Path(root)
 samplers_name = "dwave.samplers"
 samplers_dir = root / "samplers"
 
-def build_spec_or_raise(name, location, submodule_search_locations=None, importlib=importlib):
+def build_spec_or_raise(name, location, submodule_search_locations=None, importlib_util=importlib_util):
     if not location.exists():
         raise ImportError(f"Could not build module spec for {name} from {location}")
-    spec = importlib.util.spec_from_file_location(
+    spec = importlib_util.spec_from_file_location(
         name,
         location,
         submodule_search_locations=submodule_search_locations,
@@ -125,7 +125,7 @@ def ensure_package_stub(
     parent_pkg=None,
     attr_name=None,
     sys=sys,
-    importlib=importlib,
+    importlib_util=importlib_util,
     build_spec_or_raise=build_spec_or_raise,
 ):
     expected_path = [str(directory)]
@@ -136,7 +136,7 @@ def ensure_package_stub(
             directory / "__init__.py",
             submodule_search_locations=expected_path,
         )
-        pkg_mod = importlib.util.module_from_spec(pkg_spec)
+        pkg_mod = importlib_util.module_from_spec(pkg_spec)
         # Register a package stub with the real search path, but do not execute
         # __init__ because that would eagerly import unrelated samplers.
         sys.modules[name] = pkg_mod
@@ -171,7 +171,7 @@ if leaf_is_package:
         leaf_dir / "__init__.py",
         submodule_search_locations=[str(leaf_dir)],
     )
-    leaf_mod = importlib.util.module_from_spec(leaf_spec)
+    leaf_mod = importlib_util.module_from_spec(leaf_spec)
     sys.modules[leaf_name] = leaf_mod
     setattr(parent_pkg, leaf, leaf_mod)
     leaf_spec.loader.exec_module(leaf_mod)
@@ -180,7 +180,7 @@ else:
         leaf_name,
         parent_dir / f"{leaf}.py",
     )
-    leaf_mod = importlib.util.module_from_spec(leaf_spec)
+    leaf_mod = importlib_util.module_from_spec(leaf_spec)
     sys.modules[leaf_name] = leaf_mod
     setattr(parent_pkg, leaf, leaf_mod)
     leaf_spec.loader.exec_module(leaf_mod)


### PR DESCRIPTION
## Summary

`pyimport("importlib")` does not load `importlib.util` as a submodule attribute in Python 3.10+. This causes `DWave.Neal.__init__` to fail with `AttributeError: module 'importlib' has no attribute 'util'` when the narrow import path runs.

## Fix

Pass `importlib_util = pyimport("importlib.util")` directly instead of `importlib = pyimport("importlib")`, and update the Python code string to use `importlib_util` throughout.

## Testing

All 618 DWave.jl tests pass. Reproduced from the QuIP Notebook 5 cache smoke test.

Bumps version to 0.6.2.