### PR TITLE
Expose solver metadata (dwave_info) for Neal sampler

### DIFF
--- a/src/classical.jl
+++ b/src/classical.jl
@@ -259,7 +259,6 @@ function _format_classical_sampleset(
     α,
     β;
     origin::String,
-    include_dwave_info::Bool = true,
 ) where {T}
     samples = QUBOTools.Sample{T,Int}[]
     var_map = pyconvert.(Int, [var for var in results.value.variables]) .+ 1
@@ -286,11 +285,8 @@ function _format_classical_sampleset(
         "time" => Dict{String,Any}(
             "effective" => results.time,
         ),
+        "dwave_info" => jl_object(results.value.info),
     )
-
-    if include_dwave_info
-        metadata["dwave_info"] = jl_object(results.value.info)
-    end
 
     return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
 end

--- a/src/neal/sampler.jl
+++ b/src/neal/sampler.jl
@@ -71,15 +71,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     py_sampler = dwave_samplers.SimulatedAnnealingSampler()
     results = @timed py_sampler.sample_ising(Py(h), Py(J); params...)
 
-    return DWave._format_classical_sampleset(
-        T,
-        results,
-        n,
-        α,
-        β;
-        origin = "D-Wave Neal",
-        include_dwave_info = false,
-    )
+    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Neal")
 end
 
 end # module Neal

--- a/test/neal_parity.jl
+++ b/test/neal_parity.jl
@@ -322,7 +322,7 @@ Test.@testset "Neal parity with sparse support" begin
     Test.@test all(all(abs.(record.state) .== 1) for record in wrapper_records)
 end
 
-Test.@testset "Neal metadata remains backward compatible" begin
+Test.@testset "Neal metadata includes solver info" begin
     h = [0.0, -1.0]
     J = zeros(Float64, 2, 2)
     J[1, 2] = -1.0
@@ -332,5 +332,12 @@ Test.@testset "Neal metadata remains backward compatible" begin
 
     Test.@test haskey(metadata, "origin")
     Test.@test haskey(metadata, "time")
-    Test.@test !haskey(metadata, "dwave_info")
+    Test.@test haskey(metadata, "dwave_info")
+
+    info = metadata["dwave_info"]
+    Test.@test haskey(info, "beta_range")
+    Test.@test haskey(info, "beta_schedule_type")
+    Test.@test haskey(info, "timing")
+    Test.@test length(info["beta_range"]) == 2
+    Test.@test info["timing"] isa Dict
 end


### PR DESCRIPTION
## Summary

Exposes the upstream Python solver metadata (`beta_range`, `beta_schedule_type`, `timing`) in the Neal wrapper's `QUBOTools.metadata` output under the `"dwave_info"` key.

Fixes #23.

## What changed

- **`src/neal/sampler.jl`**: Removed the `include_dwave_info = false` override so Neal uses the same default as all other classical samplers.
- **`src/classical.jl`**: Removed the now-unused `include_dwave_info` parameter from `_format_classical_sampleset` and moved the `dwave_info` key into the metadata dict literal since it is always included.

## Rationale

The `include_dwave_info` flag existed only because Neal predated the other classical wrappers. Since v0.6.0 ships all four wrappers with `dwave_info` enabled by default, there is no reason to treat Neal differently. The info dict is small (a few scalars and a 3-key timing dict) and is always available from the Python sampler, so there is no performance or compatibility reason to suppress it.

## Validation

```
julia --project=. -e 'using Pkg; Pkg.test()'
```

All tests pass, including the new "Neal metadata includes solver info" testset (8 assertions).