### PR TITLE
Include D-Wave chip info in metadata

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -14,6 +14,84 @@ QUBODrivers.@setup Optimizer begin
     end
 end
 
+const _DWAVE_CHIP_INFO_KEYS = ("chip_id", "topology", "solver_name", "category")
+
+function _maybe_getproperty(object, name::Symbol)
+    try
+        return getproperty(object, name)
+    catch
+        return nothing
+    end
+end
+
+function _as_julia_metadata(value)
+    value === nothing && return nothing
+
+    if value isa AbstractString ||
+       value isa Number ||
+       value isa Bool ||
+       value isa AbstractDict ||
+       value isa AbstractVector
+        return value
+    end
+
+    try
+        return jl_object(value)
+    catch
+        return nothing
+    end
+end
+
+function _metadata_property(properties, key::String)
+    if properties isa AbstractDict
+        haskey(properties, key) || return nothing
+
+        return _as_julia_metadata(properties[key])
+    end
+
+    try
+        pyconvert(Bool, properties.__contains__(key)) || return nothing
+
+        return _as_julia_metadata(properties[key])
+    catch
+        return nothing
+    end
+end
+
+function _dwave_solver_name(dwave_sampler)
+    solver = _maybe_getproperty(dwave_sampler, :solver)
+    solver === nothing && return nothing
+
+    for name in (:name, :id)
+        value = _as_julia_metadata(_maybe_getproperty(solver, name))
+        value === nothing || return value
+    end
+
+    return nothing
+end
+
+function _dwave_chip_info(dwave_sampler)
+    base_sampler = something(_maybe_getproperty(dwave_sampler, :child), dwave_sampler)
+    chip_info = Dict{String,Any}()
+    properties = _maybe_getproperty(base_sampler, :properties)
+
+    if properties !== nothing
+        for key in _DWAVE_CHIP_INFO_KEYS
+            value = _metadata_property(properties, key)
+            value === nothing && continue
+
+            chip_info[key] = value
+        end
+    end
+
+    if !haskey(chip_info, "solver_name")
+        value = _dwave_solver_name(base_sampler)
+        value === nothing || (chip_info["solver_name"] = value)
+    end
+
+    return chip_info
+end
+
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     # Ising Model
     n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
@@ -40,6 +118,11 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     results = @timed dwave_sampler.sample_ising(h, J; sample_params...)
     var_map = pyconvert.(Int, [var for var in results.value.variables])
     dw_info = jl_object(results.value.info)
+    chip_info = _dwave_chip_info(dwave_sampler)
+
+    if !isempty(chip_info)
+        dw_info["chip_info"] = chip_info
+    end
 
     for (ϕ, λ, r) in results.value.record
         # the dwave sampler will not consider variables that are not

--- a/test/dwave_metadata.jl
+++ b/test/dwave_metadata.jl
@@ -1,0 +1,87 @@
+import DWave
+import QUBODrivers
+import QUBOTools
+import Test
+
+const MOI = QUBODrivers.MOI
+
+function _fake_embedding_sampler()
+    ans = DWave.PythonCall.pyexec(
+        @NamedTuple{sampler::DWave.PythonCall.Py},
+        """
+class FakeEmbeddingSampler:
+    def __init__(self):
+        self.child = type("FakeChildSampler", (), {})()
+        self.child.properties = {
+            "chip_id": "mock-chip",
+            "topology": {"type": "zephyr", "shape": [4, 4]},
+            "category": "qpu",
+        }
+        self.child.solver = type("FakeSolver", (), {"name": "Advantage_system6.4"})()
+
+    def sample_ising(self, h, J, **params):
+        return type(
+            "FakeSampleSet",
+            (),
+            {
+                "variables": [1, 2],
+                "record": [([1, -1], -1.25, 3)],
+                "info": {
+                    "problem_id": "mock-problem",
+                    "timing": {"qpu_access_time": 42},
+                },
+            },
+        )()
+
+sampler = FakeEmbeddingSampler()
+""",
+        @__MODULE__,
+        (),
+    )
+
+    return ans.sampler
+end
+
+function _wrapper_dwave_sampleset(sampler)
+    model = MOI.instantiate(DWave.Optimizer; with_bridge_type = Float64)
+    variables, _ = MOI.add_constrained_variables(model, fill(QUBODrivers.Spin(), 2))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarQuadraticTerm{Float64}[
+                MOI.ScalarQuadraticTerm{Float64}(-1.0, variables[1], variables[2]),
+            ],
+            MOI.ScalarAffineTerm{Float64}[
+                MOI.ScalarAffineTerm{Float64}(0.5, variables[1]),
+                MOI.ScalarAffineTerm{Float64}(-0.25, variables[2]),
+            ],
+            0.0,
+        ),
+    )
+    MOI.set(model, MOI.RawOptimizerAttribute("sampler"), sampler)
+
+    MOI.optimize!(model)
+
+    return QUBOTools.solution(MOI.get(model, MOI.RawSolver()))
+end
+
+Test.@testset "DWave metadata includes chip info" begin
+    metadata = QUBOTools.metadata(_wrapper_dwave_sampleset(_fake_embedding_sampler()))
+
+    Test.@test haskey(metadata, "dwave_info")
+
+    info = metadata["dwave_info"]
+    Test.@test info["problem_id"] == "mock-problem"
+    Test.@test info["timing"]["qpu_access_time"] == 42
+    Test.@test haskey(info, "chip_info")
+
+    chip_info = info["chip_info"]
+    Test.@test chip_info["chip_id"] == "mock-chip"
+    Test.@test chip_info["category"] == "qpu"
+    Test.@test chip_info["solver_name"] == "Advantage_system6.4"
+    Test.@test chip_info["topology"]["type"] == "zephyr"
+    Test.@test chip_info["topology"]["shape"] == Any[4, 4]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,3 +14,4 @@ QUBODrivers.test(DWave.Tabu.Optimizer; examples = true)
 
 include("neal_parity.jl")
 include("classical_parity.jl")
+include("dwave_metadata.jl")


### PR DESCRIPTION
## Summary

- Adds `chip_info` to `metadata["dwave_info"]` for `DWave.Optimizer` results when solver properties are available.
- Reads chip ID, topology, solver name, and category from the underlying D-Wave sampler, including `EmbeddingComposite.child`.
- Adds a fake-sampler regression test that does not require a live D-Wave token.

## Tests run

- `julia +1.12 --project=. test/dwave_metadata.jl` - passed, 9/9 tests.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` - passed.

## Notes

- Local live QPU tests were skipped because `DWAVE_API_TOKEN` is not set.
- Reviewed #14 as the first attempt; this PR keeps the implementation narrower and adds coverage.

Closes #11
