### PR TITLE
Release v0.6.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"


### PR DESCRIPTION
## Summary

- Bump DWave.jl to v0.6.4.
- Prepare release notes for the Registrator/TagBot release.

## Release notes

## DWave v0.6.4

[Diff since v0.6.3](https://github.com/JuliaQUBO/DWave.jl/compare/v0.6.3...v0.6.4)

## Bug fixes

- Fixed Neal sparse model conversion so sparse quadratic terms are preserved when building the upstream D-Wave BQM input (fixes #18).
- Propagated D-Wave chip metadata from solver properties into `QUBOTools.metadata(sampleset)["dwave_info"]` (fixes #11).

## Compatibility and maintenance

- Added compatibility for QUBODrivers 0.4 and QUBOTools 0.12 while keeping the Julia floor at 1.10.
- Updated the Python/Ocean stack to D-Wave Ocean SDK 9.3.0, NumPy 2.4.6, dwave-networkx 0.8.18, and Python 3.11-3.13.
- Modernized CI to run on Julia 1.10 and latest stable Julia across Ubuntu and Windows.

**Merged pull requests:**
- Fix Neal sparse model conversion (#26) (@bernalde)
- Fix chip metadata in D-Wave info (#27) (@bernalde)
- Modernize Julia CI and JuliaQUBO compat (#28) (@bernalde)

**Closed issues:**
- Classical Neal sampler does not support sparse QUBO input (#18)
- Include chip and solver metadata in D-Wave sample info (#11)
- Modernize Julia CI and update JuliaQUBO compatibility (#25)

## Tests

- `git diff --check` - passed.
- `julia +1.10 --project=. -e 'import Pkg; Pkg.test()'` - passed. D-Wave cloud tests were skipped locally because `DWAVE_API_TOKEN` is not set.

## Notes

- CI should cover Julia 1.10 and latest stable Julia on Ubuntu and Windows.
