### PR TITLE
Clean legacy DWave repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ To use D-Wave's QPU it is necessary to obtain an API Token from [Leap](https://c
 
 **Disclaimer:** _The D-Wave wrapper for Julia is not officially supported by D-Wave Systems. If you are a commercial customer interested in official support for Julia from D-Wave, let them know!_
 
-**Note**: _If you are using [DWave.jl](https://github.com/psrenergy/DWave.jl) in your project, we recommend you to include the `.CondaPkg` entry in your `.gitignore` file. The PythonCall module will place a lot of files in this folder when building its Python environment._
+**Note**: _If you are using [DWave.jl](https://github.com/JuliaQUBO/DWave.jl) in your project, we recommend you to include the `.CondaPkg` entry in your `.gitignore` file. The PythonCall module will place a lot of files in this folder when building its Python environment._


### PR DESCRIPTION
Summary:
- Replace the last stale `psrenergy/DWave.jl` README link with the canonical `JuliaQUBO/DWave.jl` URL.

Tests run:
- `git diff --check` - passed
- `git grep -n -i -E 'psrenergy|pmacielx'` - no tracked-file matches

Notes:
- No Julia test suite run; this is a README-only link cleanup.
