### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:


### PR DESCRIPTION
Summary:
- Update GitHub Actions workflow actions that emitted Node.js 20 deprecation warnings.
- Move `actions/checkout` from `v4` to `v6`.
- Move `julia-actions/setup-julia` from `v2` to `v3`.
- Add `julia-actions/cache@v3` before build/test to address the Julia cache advisory and speed up CI.

Tests run:
- `git diff --check` - passed
- `ruby -e "require 'yaml'; YAML.load_file(ARGV[0]); puts 'ok'" .github/workflows/ci.yml` - passed

Notes:
- No local Julia test suite was run because this PR only changes the GitHub Actions workflow. The PR CI matrix is the relevant validation.
