### PR TITLE
Add Dependabot dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -27,6 +27,20 @@ Test.@testset "CI covers Julia floor and latest stable" begin
     Test.@test !occursin("1.12", workflow)
 end
 
+Test.@testset "Dependency maintenance automation follows policy" begin
+    dependabot = read(joinpath(PACKAGE_ROOT, ".github", "dependabot.yml"), String)
+    workflows = readdir(joinpath(PACKAGE_ROOT, ".github", "workflows"))
+
+    Test.@test occursin(r"(?m)^\s*-\s*package-ecosystem:\s*\"julia\"\s*$", dependabot)
+    Test.@test occursin(r"(?m)^\s*directory:\s*\"/\"\s*$", dependabot)
+    Test.@test occursin("root-julia-dependencies", dependabot)
+    Test.@test occursin(r"(?m)^\s*-\s*package-ecosystem:\s*\"github-actions\"\s*$", dependabot)
+    Test.@test occursin(r"(?m)^\s*interval:\s*\"monthly\"\s*$", dependabot)
+    Test.@test !occursin(r"(?m)^\s*directory:\s*\"/docs\"\s*$", dependabot)
+    Test.@test !occursin(r"(?m)^\s*directory:\s*\"/test\"\s*$", dependabot)
+    Test.@test !any(name -> occursin("compathelper", lowercase(name)), workflows)
+end
+
 Test.@testset "Python dependencies match audited stable stack" begin
     condapkg = TOML.parsefile(joinpath(PACKAGE_ROOT, "CondaPkg.toml"))
     pip_deps = condapkg["pip"]["deps"]


### PR DESCRIPTION
Summary:
- Add `.github/dependabot.yml` with weekly grouped Julia updates for the root package environment.
- Add monthly GitHub Actions update checks.
- Add metadata regression coverage so CI catches accidental CompatHelper or Dependabot policy drift.

Secrets and permissions:
- No repository secret or PAT is required for routine Dependabot PRs in this public repository because DWave.jl depends on the public Julia General registry.
- The default Dependabot/GitHub token path is sufficient for this repository.
- A PAT would only be needed for a future private/custom registry case or a workflow that must trigger privileged cross-repository automation.
- No docs workflow exists in this repository, so the Documenter preview `--skip-deploy` guard used in upstream rollout repositories is not needed here.

Tests:
- `julia --project=test test/compat_metadata.jl`
- `julia --project=. -e 'import Pkg; Pkg.test()'`

Note: `DWave.Optimizer` cloud tests were skipped locally because `DWAVE_API_TOKEN` is not set.

Closes #34
