### PR TITLE
[codex] Support QUBODrivers 0.6 conformance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.6.6"
+version = "0.7.0"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
@@ -15,7 +15,7 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 Graphs           = "1"
 JSON             = "0.21, 1.6"
 MathOptInterface = "1"
-QUBODrivers      = "0.3.3, 0.4, 0.5, 0.6"
-QUBOTools        = "0.10, 0.11, 0.12, 0.13"
+QUBODrivers      = "0.6.1"
+QUBOTools        = "0.13"
 PythonCall       = "0.9.26"
 julia            = "1.10"

--- a/src/DWave.jl
+++ b/src/DWave.jl
@@ -116,19 +116,29 @@ function _metadata_base(;
     optimizer_evaluations = final_number_of_reads,
     seeds::Dict{String,Any} = Dict{String,Any}(),
 )
-    return QUBODrivers._sampler_metadata(
-        origin = origin,
-        algorithm_name = algorithm_name,
-        backend_name = _OCEAN_BACKEND_NAME,
-        backend_version = OCEAN_SDK_VERSION,
-        execution_mode = execution_mode,
-        optimizer_iterations = optimizer_iterations,
-        optimizer_evaluations = optimizer_evaluations,
-        number_of_reads = number_of_reads,
-        final_number_of_reads = final_number_of_reads,
-        seeds = seeds,
-        status = "locally_solved",
-        termination_status = MOI.LOCALLY_SOLVED,
+    return Dict{String,Any}(
+        "origin" => origin,
+        "algorithm" => Dict{String,Any}(
+            "name" => algorithm_name,
+        ),
+        "backend" => Dict{String,Any}(
+            "name" => _OCEAN_BACKEND_NAME,
+            "version" => OCEAN_SDK_VERSION,
+        ),
+        "execution" => Dict{String,Any}(
+            "mode" => execution_mode,
+        ),
+        "optimizer" => Dict{String,Any}(
+            "iterations" => optimizer_iterations,
+            "evaluations" => optimizer_evaluations,
+        ),
+        "reads" => Dict{String,Any}(
+            "number_of_reads" => number_of_reads,
+            "final_number_of_reads" => final_number_of_reads,
+        ),
+        "seeds" => seeds,
+        "status" => "locally_solved",
+        "termination_status" => MOI.LOCALLY_SOLVED,
     )
 end
 

--- a/src/DWave.jl
+++ b/src/DWave.jl
@@ -18,6 +18,19 @@ const dwave_networkx  = PythonCall.pynew()
 const dwave_system    = PythonCall.pynew()
 
 const API_TOKEN = Ref{Union{String,Nothing}}(nothing)
+const OCEAN_SDK_VERSION = v"9.3.0"
+const _OCEAN_BACKEND_NAME = "dwave-ocean-sdk"
+const _DWAVE_TIMING_MICROSECOND_KEYS = (
+    "qpu_access_time",
+    "qpu_sampling_time",
+    "qpu_anneal_time_per_sample",
+    "qpu_readout_time_per_sample",
+    "qpu_delay_time_per_sample",
+    "qpu_programming_time",
+    "qpu_access_overhead_time",
+    "total_post_processing_time",
+    "post_processing_overhead_time",
+)
 
 function __auth__(; verbose :: Bool = false)
     # D-Wave API Credentials
@@ -91,6 +104,73 @@ function jl_object(py_obj)
     data = pyconvert(String, json.dumps(py_obj))
 
     return _json_data(JSON.parse(data))
+end
+
+function _metadata_base(;
+    origin::String,
+    algorithm_name::String,
+    execution_mode::String,
+    number_of_reads::Integer,
+    final_number_of_reads::Integer = number_of_reads,
+    optimizer_iterations = nothing,
+    optimizer_evaluations = final_number_of_reads,
+    seeds::Dict{String,Any} = Dict{String,Any}(),
+)
+    return QUBODrivers._sampler_metadata(
+        origin = origin,
+        algorithm_name = algorithm_name,
+        backend_name = _OCEAN_BACKEND_NAME,
+        backend_version = OCEAN_SDK_VERSION,
+        execution_mode = execution_mode,
+        optimizer_iterations = optimizer_iterations,
+        optimizer_evaluations = optimizer_evaluations,
+        number_of_reads = number_of_reads,
+        final_number_of_reads = final_number_of_reads,
+        seeds = seeds,
+        status = "locally_solved",
+        termination_status = MOI.LOCALLY_SOLVED,
+    )
+end
+
+function _seed_metadata(seed)
+    return isnothing(seed) ? Dict{String,Any}() : Dict{String,Any}("sampler" => seed)
+end
+
+function _dwave_timing(dwave_info::AbstractDict)
+    timing = get(dwave_info, "timing", nothing)
+
+    timing isa AbstractDict || return Dict{String,Any}()
+
+    return Dict{String,Any}(string(k) => v for (k, v) in pairs(timing))
+end
+
+function _dwave_timing_seconds(value)
+    value isa Real || return nothing
+
+    return value / 1_000_000
+end
+
+function _dwave_effective_time(dwave_info::AbstractDict, fallback::Real)
+    timing = _dwave_timing(dwave_info)
+    access_time = get(timing, "qpu_access_time", nothing)
+    effective = _dwave_timing_seconds(access_time)
+
+    return isnothing(effective) ? fallback : effective
+end
+
+function _attach_dwave_timing!(metadata::Dict{String,Any}, dwave_info::AbstractDict)
+    timing = _dwave_timing(dwave_info)
+
+    isempty(timing) && return metadata
+
+    metadata["time"]["dwave"] = Dict{String,Any}(
+        "timing" => timing,
+        "units" => Dict{String,Any}(
+            key => "microseconds" for key in keys(timing) if key in _DWAVE_TIMING_MICROSECOND_KEYS
+        ),
+    )
+
+    return metadata
 end
 
 include("sampler.jl")

--- a/src/classical.jl
+++ b/src/classical.jl
@@ -259,9 +259,14 @@ function _format_classical_sampleset(
     α,
     β;
     origin::String,
+    algorithm_name::String,
+    number_of_reads = nothing,
+    final_number_of_reads = number_of_reads,
+    seed = nothing,
 ) where {T}
     samples = QUBOTools.Sample{T,Int}[]
     var_map = pyconvert.(Int, [var for var in results.value.variables]) .+ 1
+    observed_reads = 0
 
     for row in results.value.record
         ψ = zeros(Int, n)
@@ -270,23 +275,33 @@ function _format_classical_sampleset(
             ψ[var_map[i]] = pyconvert(Int, v)
         end
 
+        reads = pyconvert(Int, row["num_occurrences"])
+        observed_reads += reads
+
         push!(
             samples,
             QUBOTools.Sample{T,Int}(
                 ψ,
                 α * (pyconvert(T, row["energy"]) + β),
-                pyconvert(Int, row["num_occurrences"]),
+                reads,
             ),
         )
     end
 
-    metadata = Dict{String,Any}(
-        "origin" => origin,
-        "time" => Dict{String,Any}(
-            "effective" => results.time,
-        ),
-        "dwave_info" => jl_object(results.value.info),
+    dwave_info = jl_object(results.value.info)
+    metadata_number_of_reads = something(number_of_reads, observed_reads)
+    metadata_final_number_of_reads = something(final_number_of_reads, observed_reads)
+    metadata = _metadata_base(
+        origin = origin,
+        algorithm_name = algorithm_name,
+        execution_mode = "local",
+        number_of_reads = metadata_number_of_reads,
+        final_number_of_reads = metadata_final_number_of_reads,
+        seeds = _seed_metadata(seed),
     )
+    metadata["time"] = Dict{String,Any}("effective" => results.time)
+    _attach_dwave_timing!(metadata, dwave_info)
+    metadata["dwave_info"] = dwave_info
 
     return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
 end

--- a/src/greedy/sampler.jl
+++ b/src/greedy/sampler.jl
@@ -27,23 +27,28 @@ D-Wave's steepest-descent sampler for QUBO and Ising models.
 """
 QUBODrivers.@setup Optimizer begin
     name       = "D-Wave Greedy Steepest Descent Sampler"
-    version    = v"9.3.0" # dwave-ocean-sdk version
+    version    = DWave.OCEAN_SDK_VERSION
     attributes = begin
         # Delegate `nothing` to the upstream sampler, which infers num_reads
         # from initial_states or defaults to a single read.
         "num_reads"::Union{Integer,Nothing} = nothing
         "initial_states"::Any = nothing
         "initial_states_generator"::String = "random"
-        "seed"::Union{Integer,Nothing} = nothing
+        RandomSeed["seed"]::Union{Integer,Nothing} = nothing
         "large_sparse_opt"::Bool = false
     end
 end
 
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
+
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
 
+    num_reads = MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads"))
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    seed = MOI.get(sampler, QUBODrivers.RandomSeed())
     params = Dict{Symbol,Any}(
-        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
+        :num_reads => final_num_reads,
         :initial_states => DWave._normalize_initial_states(
             n,
             MOI.get(sampler, MOI.RawOptimizerAttribute("initial_states")),
@@ -52,13 +57,24 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
             sampler,
             MOI.RawOptimizerAttribute("initial_states_generator"),
         ),
-        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
+        :seed => seed,
         :large_sparse_opt => MOI.get(sampler, MOI.RawOptimizerAttribute("large_sparse_opt")),
     )
 
     results = @timed dwave_samplers.SteepestDescentSampler().sample_ising(Py(h), Py(J); params...)
 
-    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Greedy")
+    return DWave._format_classical_sampleset(
+        T,
+        results,
+        n,
+        α,
+        β;
+        origin = "D-Wave Greedy",
+        algorithm_name = "D-Wave Greedy Steepest Descent Sampler",
+        number_of_reads = num_reads,
+        final_number_of_reads = final_num_reads,
+        seed = seed,
+    )
 end
 
 end # module Greedy

--- a/src/neal/sampler.jl
+++ b/src/neal/sampler.jl
@@ -39,7 +39,7 @@ D-Wave's Simulated Annealing Sampler for QUBO and Ising models.
 """
 QUBODrivers.@setup Optimizer begin
     name       = "D-Wave Neal Simulated Annealing Sampler"
-    version    = v"9.3.0" # dwave-ocean-sdk version
+    version    = DWave.OCEAN_SDK_VERSION
     attributes = begin
         "num_reads"::Integer = 1_000
         "num_sweeps"::Integer = 1_000
@@ -47,11 +47,13 @@ QUBODrivers.@setup Optimizer begin
         "beta_range"::Union{Tuple{Float64,Float64},Nothing} = nothing
         "beta_schedule"::Union{Vector,Nothing} = nothing
         "beta_schedule_type"::String = "geometric"
-        "seed"::Union{Integer,Nothing} = nothing
+        RandomSeed["seed"]::Union{Integer,Nothing} = nothing
         "initial_states_generator"::String = "random"
         "interrupt_function"::Union{Function,Nothing} = nothing
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
 
 function _sparse_ising_bqm(n::Int, h::Dict{Int,T}, J::Dict{Tuple{Int,Int},T}) where {T}
     linear = zeros(T, n)
@@ -87,22 +89,39 @@ end
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
 
+    num_reads = MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads"))
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    seed = MOI.get(sampler, QUBODrivers.RandomSeed())
     params = Dict{Symbol,Any}(
-        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
+        :num_reads => final_num_reads,
         :num_sweeps => MOI.get(sampler, MOI.RawOptimizerAttribute("num_sweeps")),
         :num_sweeps_per_beta => MOI.get(sampler, MOI.RawOptimizerAttribute("num_sweeps_per_beta")),
         :beta_range => MOI.get(sampler, MOI.RawOptimizerAttribute("beta_range")),
         :beta_schedule => MOI.get(sampler, MOI.RawOptimizerAttribute("beta_schedule")),
         :beta_schedule_type => MOI.get(sampler, MOI.RawOptimizerAttribute("beta_schedule_type")),
-        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
-        :initial_states_generator => MOI.get(sampler, MOI.RawOptimizerAttribute("initial_states_generator")),
+        :seed => seed,
+        :initial_states_generator => MOI.get(
+            sampler,
+            MOI.RawOptimizerAttribute("initial_states_generator"),
+        ),
         :interrupt_function => MOI.get(sampler, MOI.RawOptimizerAttribute("interrupt_function")),
     )
 
     py_sampler = dwave_samplers.SimulatedAnnealingSampler()
     results = @timed py_sampler.sample(_sparse_ising_bqm(n, h, J); params...)
 
-    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Neal")
+    return DWave._format_classical_sampleset(
+        T,
+        results,
+        n,
+        α,
+        β;
+        origin = "D-Wave Neal",
+        algorithm_name = "D-Wave Neal Simulated Annealing Sampler",
+        number_of_reads = num_reads,
+        final_number_of_reads = final_num_reads,
+        seed = seed,
+    )
 end
 
 end # module Neal

--- a/src/random/sampler.jl
+++ b/src/random/sampler.jl
@@ -27,28 +27,47 @@ D-Wave's random sampler for QUBO and Ising models.
 """
 QUBODrivers.@setup Optimizer begin
     name       = "D-Wave Random Sampler"
-    version    = v"9.3.0" # dwave-ocean-sdk version
+    version    = DWave.OCEAN_SDK_VERSION
     attributes = begin
         "num_reads"::Union{Integer,Nothing} = nothing
         "time_limit"::Union{Real,Nothing} = nothing
         "max_num_samples"::Integer = 1_000
-        "seed"::Union{Integer,Nothing} = nothing
+        RandomSeed["seed"]::Union{Integer,Nothing} = nothing
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
+QUBODrivers.enforces_time_limit(::Type{<:Optimizer}) = true
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
 
+    num_reads = MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads"))
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    time_limit = MOI.get(sampler, MOI.RawOptimizerAttribute("time_limit"))
+    moi_time_limit = MOI.get(sampler, MOI.TimeLimitSec())
+    seed = MOI.get(sampler, QUBODrivers.RandomSeed())
     params = Dict{Symbol,Any}(
-        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
-        :time_limit => MOI.get(sampler, MOI.RawOptimizerAttribute("time_limit")),
+        :num_reads => final_num_reads,
+        :time_limit => isnothing(time_limit) ? moi_time_limit : time_limit,
         :max_num_samples => MOI.get(sampler, MOI.RawOptimizerAttribute("max_num_samples")),
-        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
+        :seed => seed,
     )
 
     results = @timed dwave_samplers.RandomSampler().sample_ising(Py(h), Py(J); params...)
 
-    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Random")
+    return DWave._format_classical_sampleset(
+        T,
+        results,
+        n,
+        α,
+        β;
+        origin = "D-Wave Random",
+        algorithm_name = "D-Wave Random Sampler",
+        number_of_reads = num_reads,
+        final_number_of_reads = final_num_reads,
+        seed = seed,
+    )
 end
 
 end # module Random

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -5,7 +5,7 @@ D-Wave's Quantum Annealing Sampler for QUBO and Ising models.
 """
 QUBODrivers.@setup Optimizer begin
     name       = "D-Wave Quantum Annealing Sampler"
-    version    = v"9.3.0" # dwave-ocean-sdk version
+    version    = DWave.OCEAN_SDK_VERSION
     attributes = begin
         NumberOfReads["num_reads"]::Integer       = 100
         Sampler["sampler"]::Any                   = nothing
@@ -13,6 +13,8 @@ QUBODrivers.@setup Optimizer begin
         AnnealingTime["annealing_time"]::Float64  = 20.0
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
 
 const _DWAVE_CHIP_INFO_KEYS = ("chip_id", "topology", "solver_name", "category")
 
@@ -97,8 +99,10 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     n, h, J, α, β = QUBOTools.ising(sampler, :dict; sense = :min)
 
     # Attributes
+    num_reads = MOI.get(sampler, DWave.NumberOfReads())
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
     sample_params = Dict{Symbol,Any}(
-        :num_reads      => MOI.get(sampler, DWave.NumberOfReads()),
+        :num_reads      => final_num_reads,
         :annealing_time => MOI.get(sampler, DWave.AnnealingTime()),
     )
     dwave_sampler = MOI.get(sampler, DWave.Sampler())
@@ -149,13 +153,18 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     end
 
     # Metadata
-    metadata = Dict{String,Any}(
-        "origin" => "D-Wave",
-        "time"   => Dict{String,Any}( #
-            "effective" => results.time,
-        ),
-        "dwave_info" => dw_info,
+    metadata = DWave._metadata_base(
+        origin = "D-Wave",
+        algorithm_name = "D-Wave Quantum Annealing Sampler",
+        execution_mode = "qpu",
+        number_of_reads = num_reads,
+        final_number_of_reads = final_num_reads,
     )
+    metadata["time"] = Dict{String,Any}(
+        "effective" => DWave._dwave_effective_time(dw_info, results.time),
+    )
+    DWave._attach_dwave_timing!(metadata, dw_info)
+    metadata["dwave_info"] = dw_info
 
     return QUBOTools.SampleSet{T,Int}(samples, metadata; sense = :min, domain = :spin)
 end

--- a/src/tabu/sampler.jl
+++ b/src/tabu/sampler.jl
@@ -34,12 +34,12 @@ D-Wave's tabu-search sampler for QUBO and Ising models.
 """
 QUBODrivers.@setup Optimizer begin
     name       = "D-Wave Tabu Sampler"
-    version    = v"9.3.0" # dwave-ocean-sdk version
+    version    = DWave.OCEAN_SDK_VERSION
     attributes = begin
         "initial_states"::Any = nothing
         "initial_states_generator"::String = "random"
         "num_reads"::Union{Integer,Nothing} = nothing
-        "seed"::Union{Integer,Nothing} = nothing
+        RandomSeed["seed"]::Union{Integer,Nothing} = nothing
         "tenure"::Union{Integer,Nothing} = nothing
         "timeout"::Union{Integer,Nothing} = 20
         "num_restarts"::Integer = 1_000_000
@@ -50,9 +50,14 @@ QUBODrivers.@setup Optimizer begin
     end
 end
 
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
+
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     n, h, J, α, β = QUBOTools.ising(sampler, :dense; sense = :min)
 
+    num_reads = MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads"))
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    seed = MOI.get(sampler, QUBODrivers.RandomSeed())
     params = Dict{Symbol,Any}(
         :initial_states => DWave._normalize_initial_states(
             n,
@@ -62,8 +67,8 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
             sampler,
             MOI.RawOptimizerAttribute("initial_states_generator"),
         ),
-        :num_reads => MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")),
-        :seed => MOI.get(sampler, MOI.RawOptimizerAttribute("seed")),
+        :num_reads => final_num_reads,
+        :seed => seed,
         :tenure => MOI.get(sampler, MOI.RawOptimizerAttribute("tenure")),
         :timeout => MOI.get(sampler, MOI.RawOptimizerAttribute("timeout")),
         :num_restarts => MOI.get(sampler, MOI.RawOptimizerAttribute("num_restarts")),
@@ -81,7 +86,18 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
     results = @timed dwave_samplers.TabuSampler().sample_ising(Py(h), Py(J); params...)
 
-    return DWave._format_classical_sampleset(T, results, n, α, β; origin = "D-Wave Tabu")
+    return DWave._format_classical_sampleset(
+        T,
+        results,
+        n,
+        α,
+        β;
+        origin = "D-Wave Tabu",
+        algorithm_name = "D-Wave Tabu Sampler",
+        number_of_reads = num_reads,
+        final_number_of_reads = final_num_reads,
+        seed = seed,
+    )
 end
 
 end # module Tabu

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -1,7 +1,10 @@
+import DWave
+import QUBODrivers
 import TOML
 import Test
 
 const PACKAGE_ROOT = normpath(joinpath(@__DIR__, ".."))
+const CompatMOI = QUBODrivers.MOI
 
 function _compat_entries(value::String)
     return strip.(split(value, ','))
@@ -11,12 +14,40 @@ Test.@testset "Compatibility metadata matches supported JuliaQUBO stack" begin
     compat = TOML.parsefile(joinpath(PACKAGE_ROOT, "Project.toml"))["compat"]
 
     Test.@test compat["julia"] == "1.10"
-    Test.@test "0.3.3" in _compat_entries(compat["QUBODrivers"])
-    Test.@test "0.4" in _compat_entries(compat["QUBODrivers"])
-    Test.@test "0.5" in _compat_entries(compat["QUBODrivers"])
-    Test.@test "0.10" in _compat_entries(compat["QUBOTools"])
-    Test.@test "0.11" in _compat_entries(compat["QUBOTools"])
-    Test.@test "0.12" in _compat_entries(compat["QUBOTools"])
+    Test.@test _compat_entries(compat["QUBODrivers"]) == ["0.6.1"]
+    Test.@test _compat_entries(compat["QUBOTools"]) == ["0.13"]
+end
+
+Test.@testset "QUBODrivers 0.6 capability traits are declared" begin
+    Test.@test !QUBODrivers.supports_seed(DWave.Optimizer)
+    Test.@test QUBODrivers.supports_seed(DWave.Neal.Optimizer)
+    Test.@test QUBODrivers.supports_seed(DWave.Greedy.Optimizer)
+    Test.@test QUBODrivers.supports_seed(DWave.Random.Optimizer)
+    Test.@test QUBODrivers.supports_seed(DWave.Tabu.Optimizer)
+
+    Test.@test QUBODrivers.honors_final_reads(DWave.Optimizer)
+    Test.@test QUBODrivers.honors_final_reads(DWave.Neal.Optimizer)
+    Test.@test QUBODrivers.honors_final_reads(DWave.Greedy.Optimizer)
+    Test.@test QUBODrivers.honors_final_reads(DWave.Random.Optimizer)
+    Test.@test QUBODrivers.honors_final_reads(DWave.Tabu.Optimizer)
+
+    Test.@test !QUBODrivers.enforces_time_limit(DWave.Optimizer)
+    Test.@test !QUBODrivers.enforces_time_limit(DWave.Neal.Optimizer)
+    Test.@test !QUBODrivers.enforces_time_limit(DWave.Greedy.Optimizer)
+    Test.@test QUBODrivers.enforces_time_limit(DWave.Random.Optimizer)
+    Test.@test !QUBODrivers.enforces_time_limit(DWave.Tabu.Optimizer)
+end
+
+Test.@testset "RandomSeed aliases existing seed attributes" begin
+    model = CompatMOI.instantiate(DWave.Neal.Optimizer; with_bridge_type = Float64)
+
+    Test.@test CompatMOI.supports(model, QUBODrivers.RandomSeed())
+    Test.@test isnothing(CompatMOI.get(model, QUBODrivers.RandomSeed()))
+
+    CompatMOI.set(model, QUBODrivers.RandomSeed(), 12_345)
+
+    Test.@test CompatMOI.get(model, QUBODrivers.RandomSeed()) == 12_345
+    Test.@test CompatMOI.get(model, CompatMOI.RawOptimizerAttribute("seed")) == 12_345
 end
 
 Test.@testset "CI covers Julia floor and latest stable" begin

--- a/test/dwave_metadata.jl
+++ b/test/dwave_metadata.jl
@@ -72,6 +72,15 @@ Test.@testset "DWave metadata includes chip info" begin
     metadata = QUBOTools.metadata(_wrapper_dwave_sampleset(_fake_embedding_sampler()))
 
     Test.@test haskey(metadata, "dwave_info")
+    Test.@test isempty(QUBODrivers.validate_metadata(metadata))
+    Test.@test metadata["algorithm"]["name"] == "D-Wave Quantum Annealing Sampler"
+    Test.@test metadata["backend"]["name"] == "dwave-ocean-sdk"
+    Test.@test metadata["backend"]["version"] == DWave.OCEAN_SDK_VERSION
+    Test.@test metadata["reads"]["number_of_reads"] == 100
+    Test.@test metadata["reads"]["final_number_of_reads"] == 100
+    Test.@test metadata["time"]["effective"] == 42 / 1_000_000
+    Test.@test metadata["time"]["dwave"]["timing"]["qpu_access_time"] == 42
+    Test.@test metadata["time"]["dwave"]["units"]["qpu_access_time"] == "microseconds"
 
     info = metadata["dwave_info"]
     Test.@test info["problem_id"] == "mock-problem"

--- a/test/neal_parity.jl
+++ b/test/neal_parity.jl
@@ -431,9 +431,21 @@ Test.@testset "Neal metadata includes solver info" begin
     metadata = QUBOTools.metadata(sampleset)
 
     Test.@test haskey(metadata, "origin")
+    Test.@test haskey(metadata, "algorithm")
+    Test.@test haskey(metadata, "backend")
+    Test.@test haskey(metadata, "reads")
+    Test.@test haskey(metadata, "seeds")
     Test.@test haskey(metadata, "time")
     Test.@test haskey(metadata, "dwave_info")
+    Test.@test isempty(QUBODrivers.validate_metadata(metadata))
 
+    Test.@test metadata["algorithm"]["name"] == "D-Wave Neal Simulated Annealing Sampler"
+    Test.@test metadata["backend"]["name"] == "dwave-ocean-sdk"
+    Test.@test metadata["backend"]["version"] == DWave.OCEAN_SDK_VERSION
+    Test.@test metadata["reads"]["number_of_reads"] == 4
+    Test.@test metadata["reads"]["final_number_of_reads"] == 4
+    Test.@test metadata["seeds"]["sampler"] == 7
+    Test.@test metadata["time"]["effective"] > 0
     info = metadata["dwave_info"]
     Test.@test haskey(info, "beta_range")
     Test.@test haskey(info, "beta_schedule_type")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,15 +5,15 @@ include("compat_metadata.jl")
 include("auth.jl")
 
 if DWave.__auth__(; verbose = false)
-    QUBODrivers.test(DWave.Optimizer; examples = true)
+    QUBODrivers.test(DWave.Optimizer; examples = true, benchmark_conformance = true)
 else
     @warn "DWave.Optimizer tests skipped since API Token is missing."
 end
 
-QUBODrivers.test(DWave.Neal.Optimizer; examples = true)
-QUBODrivers.test(DWave.Greedy.Optimizer; examples = true)
-QUBODrivers.test(DWave.Random.Optimizer; examples = true)
-QUBODrivers.test(DWave.Tabu.Optimizer; examples = true)
+QUBODrivers.test(DWave.Neal.Optimizer; examples = true, benchmark_conformance = true)
+QUBODrivers.test(DWave.Greedy.Optimizer; examples = true, benchmark_conformance = true)
+QUBODrivers.test(DWave.Random.Optimizer; examples = true, benchmark_conformance = true)
+QUBODrivers.test(DWave.Tabu.Optimizer; examples = true, benchmark_conformance = true)
 
 include("neal_parity.jl")
 include("classical_parity.jl")


### PR DESCRIPTION
## Summary

- Bumps DWave.jl to `v0.7.0` and tightens compat to `QUBODrivers = "0.6.1"` and `QUBOTools = "0.13"`.
- Adopts the QUBODrivers 0.6 benchmarking metadata schema for the QPU and offline samplers, including backend, algorithm, reads, seeds, status, and effective timing fields.
- Exposes the standard `QUBODrivers.RandomSeed` alias for Neal, Greedy, Random, and Tabu while leaving the cloud QPU seed trait unsupported.
- Routes sampler output counts through `QUBODrivers.FinalNumberOfReads`, declares final-read traits, and maps `MOI.TimeLimitSec()` to the Random sampler backend time limit.
- Maps D-Wave QPU `qpu_access_time` to `metadata["time"]["effective"]` in seconds and preserves the full D-Wave timing payload under `metadata["time"]["dwave"]`.
- Runs offline `QUBODrivers.test(...; benchmark_conformance = true)` unconditionally; the cloud QPU path remains gated on `DWAVE_API_TOKEN`.

## Why

DWave.jl previously had no installable compat intersection with the QUBO.jl v0.6 benchmarking stack. The old metadata also lacked the QUBODrivers 0.6 conformance fields needed by benchmarking and TTS analysis.

## Tests

- `julia --project=. test/compat_metadata.jl`
  - Passed.
- `julia --project=. -e 'import Pkg; Pkg.test()'`
  - Passed with `DWave v0.7.0`, `QUBODrivers v0.6.1`, and `QUBOTools v0.13.1`.
  - Offline conformance passed:
    - Neal: Benchmark Conformance 13/13.
    - Greedy: Benchmark Conformance 13/13.
    - Random: Benchmark Conformance 14/14.
    - Tabu: Benchmark Conformance 13/13.
  - QPU tests were skipped because `DWAVE_API_TOKEN` was not set.
- `julia --startup-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"; import Pkg; env = mktempdir(); Pkg.activate(env); Pkg.add(Pkg.PackageSpec(name = "QUBO", version = "0.6")); Pkg.develop(Pkg.PackageSpec(path = pwd())); Pkg.resolve(); Pkg.status()'`
  - Passed.
  - Resolved `QUBO v0.6.0`, `DWave v0.7.0`, `QUBODrivers v0.6.1`, and `QUBOTools v0.13.1`.
- `julia --startup-file=no -e 'import Pkg; env = mktempdir(); Pkg.activate(env); Pkg.add([Pkg.PackageSpec(name = "PySA"), Pkg.PackageSpec(name = "CIMOptimizer")]); Pkg.develop(Pkg.PackageSpec(path = pwd())); Pkg.resolve(); Pkg.status()'`
  - Did not resolve.
  - The resolver failure is from registered `CIMOptimizer v0.1.0` requiring older `QUBODrivers`, not from `PythonCall`.
- `julia --startup-file=no -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"; import Pkg; env = mktempdir(); Pkg.activate(env); Pkg.add(Pkg.PackageSpec(name = "PySA")); Pkg.develop(Pkg.PackageSpec(path = pwd())); Pkg.resolve(); Pkg.status()'`
  - Did not resolve.
  - The resolver failure is from registered `PySA` QUBO/QUBODrivers compat, not from `PythonCall`.
- `git diff --check`
  - Passed.

## Branch Hygiene

- Base branch: `main`.
- Source branch point: `origin/main` at `6a9cf63ba9d08fee34f1b8f6cf9cda53ea4bf5de`.
- Stacked status: not stacked.
- Prerequisite PRs: none.

Refs #38
