### PR TITLE
fix: complete Chimera topology support

### DIFF
--- a/src/wrapper/chimera.jl
+++ b/src/wrapper/chimera.jl
@@ -6,7 +6,7 @@
     Chimera
     
 The format of the instance-description file starts with a line giving the size of the Chimera graph[^alex1770].
-Two numbers are given to specify an ``m \times n`` rectangle, but currently only a square (``m = n``) is accepted.
+Two numbers are given to specify an ``m \times n`` rectangle.
 
 The subsequent lines are of the form
 ```
@@ -41,64 +41,51 @@ struct Chimera <: DWaveArchitecture
 end
 
 function Chimera(
-    m::Integer = 2_048, # 2000Q
+    m::Integer = 16, # 2000Q
     n::Integer = m;
     cell_size::Integer = 8,
     precision::Integer = 5,
     degree::Union{Integer,Nothing} = nothing, 
 )
-    @assert m > 0
-    @assert n > 0
-    @assert m == n # TODO: relax
+    m > 0 || throw(ArgumentError("Chimera row count must be positive, got $m"))
+    n > 0 || throw(ArgumentError("Chimera column count must be positive, got $n"))
+    cell_size > 0 || throw(ArgumentError("Chimera cell size must be positive, got $cell_size"))
+    iseven(cell_size) || throw(ArgumentError("Chimera cell size must be even, got $cell_size"))
 
     grid_size = (m, n)
-    dimension = m * n
+    dimension = m * n * cell_size
 
-    min_degree = ceil(Int, sqrt(dimension / cell_size))
+    min_degree = max(m, n)
 
     if isnothing(degree)
         degree = min_degree
     end
 
     if degree < min_degree
-        error(
+        throw(ArgumentError(
             """
-            Error: degree of '$(degree)' was specified.
+            degree of '$(degree)' was specified.
             However, the minimum degree required for a system with '$(dimension)' sites is '$(min_degree)'.
             """,
-        )
+        ))
     end
 
-    cell_row_size = cell_size ÷ 2
+    shore_size = cell_size ÷ 2
+    coordinates = Dict{Int,NTuple{4,Int}}()
+    sizehint!(coordinates, dimension)
 
-    # These values are used to transform a variable index into a chimera 
-    # coordinate (x,y,o,i)
-    # x - row
-    # y - col
-    # o - cell_col - indicates the first or the second row of a chimera cell
-    # i - cell_col_id - indicates ids within a chimera cell
-    # Note that knowing the size of source chimera graph is essential to doing this mapping correctly
+    for x in 0:(m - 1), y in 0:(n - 1), o in 0:1, i in 0:(shore_size - 1)
+        coordinates[_chimera_index(x, y, o, i, n, shore_size)] = (x, y, o, i)
+    end
 
-    cell        = Dict{Int,Int}(i => (i ÷ cell_size) for i in 1:dimension)
-    row         = Dict{Int,Int}(i => (j ÷ degree) for (i, j) in cell)
-    col         = Dict{Int,Int}(i => (j % degree) for (i, j) in cell)
-    cell_col    = Dict{Int,Int}(i => (i % cell_size) ÷ cell_row_size for i in 1:dimension)
-    cell_col_id = Dict{Int,Int}(i => (i % cell_row_size) for i in 1:dimension)
-    
-    coordinates = Dict{Int,NTuple{4,Int}}(
-        i => (row[i], col[i], cell_col[i], cell_col_id[i])
-        for i in 1:dimension
-    )
-
-    # Get the maximum of both row id and column id (namely 'c[1]', 'c[2]')
-    effective_degree = 1 + maximum((_, c) -> max(c[1], c[2]), coordinates)
+    effective_degree = 1 + maximum(c -> max(c[1], c[2]), values(coordinates))
 
     if effective_degree > degree
-        error(
+        throw(ArgumentError(
             """
             The effective degree '$effective_degree' value is greater than the chimera degree '$(degree)', which is infeasible.
             """,
-        )
+        ))
     end
 
     return Chimera(
@@ -111,18 +98,36 @@ function Chimera(
     )
 end
 
+function _chimera_index(
+    x::Integer,
+    y::Integer,
+    o::Integer,
+    i::Integer,
+    n::Integer,
+    shore_size::Integer,
+)
+    return (((x * n + y) * 2 + o) * shore_size + i) + 1
+end
+
+function _variable_starts(model::QUBOTools.AbstractModel{V}) where {V}
+    return Dict{V,Int}(
+        QUBOTools.variable(model, i) => Int(v)
+        for (i, v) in QUBOTools.start(model)
+    )
+end
+
 function DWaveDevice(arch::Chimera, model::QUBOTools.AbstractModel{V}) where {V}
     L = collect(QUBOTools.linear_terms(model))
     Q = collect(QUBOTools.quadratic_terms(model))
     α = QUBOTools.scale(model)
     β = QUBOTools.offset(model)
 
-    γ = max( # maximum absolute value for a coefficient in 'model'
-        maximum((_, v) -> abs(v), L),
-        maximum((_, v) -> abs(v), Q),
+    γ = max(
+        isempty(L) ? 0 : maximum(abs(v) for (_, v) in L),
+        isempty(Q) ? 0 : maximum(abs(v) for (_, v) in Q),
     )
 
-    γχ =  10 ^ arch.precision / γ
+    γχ = iszero(γ) ? 1.0 : 10.0 ^ arch.precision / γ
 
     # Chimera Coefficients
     Lχ = sizehint!(Dict{V,Int}(), length(L))
@@ -131,14 +136,14 @@ function DWaveDevice(arch::Chimera, model::QUBOTools.AbstractModel{V}) where {V}
     for (i, v) in L
         xi = QUBOTools.variable(model, i) 
 
-        Lχ[xi] = round(Int, v * αχ)
+        Lχ[xi] = round(Int, v * γχ)
     end
 
     for ((i, j), v) in Q
         xi = QUBOTools.variable(model, i)
         xj = QUBOTools.variable(model, j)
 
-        Qχ[(xi, xj)] = round(Int, v * αχ)
+        Qχ[(xi, xj)] = round(Int, v * γχ)
     end
 
     αχ = 1
@@ -157,14 +162,81 @@ function DWaveDevice(arch::Chimera, model::QUBOTools.AbstractModel{V}) where {V}
             sense    = QUBOTools.sense(model),
             domain   = QUBOTools.domain(model),
             metadata = copy(QUBOTools.metadata(model)),
-            start    = QUBOTools.start(model),
+            start    = _variable_starts(model),
         ),
         factor,
     )
 end
 
-function layout(arch::Chimera)
-    # TODO: Retrieve this information from dwave-networkx?
+function _chimera_graph(arch::Chimera)
+    m, n = arch.grid_size
+    shore_size = arch.cell_size ÷ 2
+    graph = Graphs.SimpleGraph(length(arch.coordinates))
 
-    return nothing
+    for x in 0:(m - 1), y in 0:(n - 1)
+        for i in 0:(shore_size - 1), j in 0:(shore_size - 1)
+            Graphs.add_edge!(
+                graph,
+                _chimera_index(x, y, 0, i, n, shore_size),
+                _chimera_index(x, y, 1, j, n, shore_size),
+            )
+        end
+
+        if y < n - 1
+            for i in 0:(shore_size - 1)
+                Graphs.add_edge!(
+                    graph,
+                    _chimera_index(x, y, 0, i, n, shore_size),
+                    _chimera_index(x, y + 1, 0, i, n, shore_size),
+                )
+            end
+        end
+
+        if x < m - 1
+            for i in 0:(shore_size - 1)
+                Graphs.add_edge!(
+                    graph,
+                    _chimera_index(x, y, 1, i, n, shore_size),
+                    _chimera_index(x + 1, y, 1, i, n, shore_size),
+                )
+            end
+        end
+    end
+
+    return graph
+end
+
+function _chimera_points(arch::Chimera)
+    shore_size = arch.cell_size ÷ 2
+    cell_spacing = 1.0 / arch.effective_degree
+    shore_spacing = cell_spacing / (2 * shore_size)
+    points = Vector{QUBOTools.Point{2,Float64}}(undef, length(arch.coordinates))
+
+    for (index, (x, y, o, i)) in arch.coordinates
+        offset = (i - (shore_size - 1) / 2) * shore_spacing
+
+        points[index] = if o == 0
+            QUBOTools.Point{2,Float64}(y, x + offset)
+        else
+            QUBOTools.Point{2,Float64}(y + offset, x)
+        end
+    end
+
+    return points
+end
+
+function QUBOTools.topology(arch::Chimera)
+    return _chimera_graph(arch)
+end
+
+function QUBOTools.geometry(arch::Chimera)
+    return _chimera_points(arch)
+end
+
+function QUBOTools.layout(arch::Chimera)
+    return QUBOTools.Layout(QUBOTools.topology(arch), QUBOTools.geometry(arch))
+end
+
+function layout(arch::Chimera)
+    return QUBOTools.layout(arch)
 end

--- a/src/wrapper/chimera.jl
+++ b/src/wrapper/chimera.jl
@@ -182,22 +182,22 @@ function _chimera_graph(arch::Chimera)
             )
         end
 
-        if y < n - 1
-            for i in 0:(shore_size - 1)
-                Graphs.add_edge!(
-                    graph,
-                    _chimera_index(x, y, 0, i, n, shore_size),
-                    _chimera_index(x, y + 1, 0, i, n, shore_size),
-                )
-            end
-        end
-
         if x < m - 1
             for i in 0:(shore_size - 1)
                 Graphs.add_edge!(
                     graph,
+                    _chimera_index(x, y, 0, i, n, shore_size),
+                    _chimera_index(x + 1, y, 0, i, n, shore_size),
+                )
+            end
+        end
+
+        if y < n - 1
+            for i in 0:(shore_size - 1)
+                Graphs.add_edge!(
+                    graph,
                     _chimera_index(x, y, 1, i, n, shore_size),
-                    _chimera_index(x + 1, y, 1, i, n, shore_size),
+                    _chimera_index(x, y + 1, 1, i, n, shore_size),
                 )
             end
         end

--- a/test/chimera.jl
+++ b/test/chimera.jl
@@ -1,0 +1,94 @@
+module ChimeraWrapperTests
+
+import DWave
+import QUBOTools
+import Test
+
+const Graphs = DWave.Graphs
+
+abstract type DWaveArchitecture <: QUBOTools.AbstractArchitecture end
+
+include(joinpath(@__DIR__, "..", "src", "wrapper", "device.jl"))
+include(joinpath(@__DIR__, "..", "src", "wrapper", "chimera.jl"))
+
+function _edge_coordinate_pairs(arch::Chimera)
+    coordinates = arch.coordinates
+
+    return Set(
+        begin
+            src = coordinates[Graphs.src(edge)]
+            dst = coordinates[Graphs.dst(edge)]
+
+            src <= dst ? (src, dst) : (dst, src)
+        end for edge in Graphs.edges(QUBOTools.topology(QUBOTools.layout(arch)))
+    )
+end
+
+Test.@testset "Chimera supports rectangular topology coordinates" begin
+    arch = Chimera(2, 3)
+
+    Test.@test arch.grid_size == (2, 3)
+    Test.@test arch.cell_size == 8
+    Test.@test length(arch.coordinates) == 2 * 3 * 8
+    Test.@test arch.degree == 3
+    Test.@test arch.effective_degree == 3
+    Test.@test arch.coordinates[1] == (0, 0, 0, 0)
+    Test.@test arch.coordinates[4] == (0, 0, 0, 3)
+    Test.@test arch.coordinates[5] == (0, 0, 1, 0)
+    Test.@test arch.coordinates[8] == (0, 0, 1, 3)
+    Test.@test arch.coordinates[9] == (0, 1, 0, 0)
+    Test.@test arch.coordinates[41] == (1, 2, 0, 0)
+    Test.@test arch.coordinates[48] == (1, 2, 1, 3)
+end
+
+Test.@testset "Chimera layout returns topology graph and geometry" begin
+    arch = Chimera(2, 3)
+    arch_layout = QUBOTools.layout(arch)
+    graph = QUBOTools.topology(arch_layout)
+    points = QUBOTools.geometry(arch_layout)
+
+    Test.@test layout(arch) isa QUBOTools.Layout
+    Test.@test Graphs.nv(graph) == 48
+    Test.@test Graphs.ne(graph) == 124
+    Test.@test length(points) == 48
+    Test.@test points[1] == QUBOTools.Point{2,Float64}(0.0, -0.0625)
+    Test.@test points[5] == QUBOTools.Point{2,Float64}(-0.0625, 0.0)
+
+    edge_pairs = _edge_coordinate_pairs(arch)
+
+    Test.@test ((0, 0, 0, 0), (0, 0, 1, 0)) in edge_pairs
+    Test.@test ((0, 0, 0, 0), (0, 0, 1, 3)) in edge_pairs
+    Test.@test ((0, 0, 0, 0), (0, 1, 0, 0)) in edge_pairs
+    Test.@test ((0, 0, 1, 0), (1, 0, 1, 0)) in edge_pairs
+    Test.@test !(((0, 0, 0, 0), (1, 0, 0, 0)) in edge_pairs)
+    Test.@test !(((0, 0, 1, 0), (0, 1, 1, 0)) in edge_pairs)
+end
+
+Test.@testset "Chimera validates dimensions" begin
+    Test.@test_throws ArgumentError Chimera(0, 2)
+    Test.@test_throws ArgumentError Chimera(2, 0)
+    Test.@test_throws ArgumentError Chimera(2, 2; cell_size = 7)
+    Test.@test_throws ArgumentError Chimera(2, 3; degree = 2)
+end
+
+Test.@testset "Chimera device scales coefficients into integer backend" begin
+    model = QUBOTools.Model{Symbol,Float64,Int}(
+        Dict(:a => 0.5),
+        Dict((:a, :b) => -1.0);
+        scale = 2.0,
+        offset = 0.25,
+        domain = :spin,
+        start = Dict(:a => 1, :b => -1),
+    )
+    dev = DWaveDevice(Chimera(1, 1), model)
+    backend = QUBOTools.backend(dev)
+
+    Test.@test dev.factor == 200_000.0
+    Test.@test Dict(QUBOTools.linear_terms(backend)) == Dict(1 => 50_000)
+    Test.@test Dict(QUBOTools.quadratic_terms(backend)) == Dict((1, 2) => -100_000)
+    Test.@test QUBOTools.scale(backend) == 1
+    Test.@test QUBOTools.offset(backend) == 25_000
+    Test.@test QUBOTools.start(backend) == Dict(1 => 1, 2 => -1)
+end
+
+end

--- a/test/chimera.jl
+++ b/test/chimera.jl
@@ -58,10 +58,10 @@ Test.@testset "Chimera layout returns topology graph and geometry" begin
 
     Test.@test ((0, 0, 0, 0), (0, 0, 1, 0)) in edge_pairs
     Test.@test ((0, 0, 0, 0), (0, 0, 1, 3)) in edge_pairs
-    Test.@test ((0, 0, 0, 0), (0, 1, 0, 0)) in edge_pairs
-    Test.@test ((0, 0, 1, 0), (1, 0, 1, 0)) in edge_pairs
-    Test.@test !(((0, 0, 0, 0), (1, 0, 0, 0)) in edge_pairs)
-    Test.@test !(((0, 0, 1, 0), (0, 1, 1, 0)) in edge_pairs)
+    Test.@test ((0, 0, 0, 0), (1, 0, 0, 0)) in edge_pairs
+    Test.@test ((0, 0, 1, 0), (0, 1, 1, 0)) in edge_pairs
+    Test.@test !(((0, 0, 0, 0), (0, 1, 0, 0)) in edge_pairs)
+    Test.@test !(((0, 0, 1, 0), (1, 0, 1, 0)) in edge_pairs)
 end
 
 Test.@testset "Chimera validates dimensions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,4 @@ QUBODrivers.test(DWave.Tabu.Optimizer; examples = true, benchmark_conformance = 
 include("neal_parity.jl")
 include("classical_parity.jl")
 include("dwave_metadata.jl")
+include("chimera.jl")


### PR DESCRIPTION
Summary
- Supports rectangular Chimera `(m, n)` grids with deterministic linear-to-coordinate mapping.
- Implements Chimera topology and geometry through `QUBOTools.layout`, with the existing unqualified `layout` delegating to it.
- Fixes dormant wrapper bugs found during validation: pair iteration in `maximum`, coefficient scaling using `αχ` before assignment, zero-coefficient scaling, and index-keyed starts passed to variable-keyed model construction.
- Adds targeted Chimera wrapper tests for rectangular coordinates, graph edges, layout geometry, validation errors, and scaled `DWaveDevice` construction.

Tests
- `julia --project=. test/chimera.jl`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Follow-Up
- The Chimera wrapper remains part of the inactive `src/wrapper/` surface in this PR. Activating or replacing that wrapper surface is deferred to #43, where Pegasus, Zephyr, and solver working-graph support can be handled together instead of wiring in the stale HFS wrapper code here.

Branch Hygiene
- Base branch: `main`
- Source branch: `fix/issue-41-chimera-topology`
- Source branch point: `8b241970d1a09d46d71c089f533a5921a370d34a`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #41
