### PR TITLE
Clarify Chimera coordinate convention

### DIFF
--- a/src/wrapper/chimera.jl
+++ b/src/wrapper/chimera.jl
@@ -26,8 +26,9 @@ There is an edge from ``v_p`` to ``v_q`` if at least one of the following holds:
 - ``|x_p - x_q| = 1 \wedge y_p = y_q \wedge o_p = o_q = 0 \wedge i_p = i_q``
 - ``x_p = x_q \wedge |y_p-y_q| = 1 \wedge o_p = o_q = 1 \wedge i_p = i_q``
 
-The legacy HFS/alex1770-style writer emits these coordinate labels unchanged, so
-round-tripping preserves this row/column, shore-index convention.
+The legacy HFS/alex1770-style writer is currently disabled; see #48. Its
+printer emits these coordinate labels unchanged, so a revived writer would
+preserve this row/column, shore-index convention.
 
 [^alex1770]:
     `alex1770`'s QUBO-Chimera Git Repository [{git}](https://github.com/alex1770/QUBO-Chimera)

--- a/src/wrapper/chimera.jl
+++ b/src/wrapper/chimera.jl
@@ -15,8 +15,9 @@ The subsequent lines are of the form
 where `<Chimera vertex>` is specified by four numbers using the format, Chimera graph, ``C_N``:
     
 Vertices are ``v = (x, y, o, i)`` where
-- ``x, y \in [0, N - 1]`` are the horizontal, vertical coordinates of the ``K_{4, 4}``
-- ``o \in [0, 1]`` is the **orientation**: (``0 = \text{horizontally connected}``, ``1 = \text{vertically connected}``)
+- ``x`` and ``y`` are the row and column coordinates of the Chimera tile, respectively
+- ``o \in [0, 1]`` is the shore index, matching the ``dwave-networkx`` ``(i, j, u, k)`` convention:
+  ``0`` is the vertical inter-tile shore and ``1`` is the horizontal inter-tile shore
 - ``i \in [0, 3]`` is the index within the "semi-``K_{4,4}``" or "bigvertex"
 - There is an involution given by ``x \iff y``, ``o \iff 1 - o``
 
@@ -24,6 +25,9 @@ There is an edge from ``v_p`` to ``v_q`` if at least one of the following holds:
 - ``(x_p, y_p) = (x_q, y_q) \wedge o_p \neq o_q``
 - ``|x_p - x_q| = 1 \wedge y_p = y_q \wedge o_p = o_q = 0 \wedge i_p = i_q``
 - ``x_p = x_q \wedge |y_p-y_q| = 1 \wedge o_p = o_q = 1 \wedge i_p = i_q``
+
+The legacy HFS/alex1770-style writer emits these coordinate labels unchanged, so
+round-tripping preserves this row/column, shore-index convention.
 
 [^alex1770]:
     `alex1770`'s QUBO-Chimera Git Repository [{git}](https://github.com/alex1770/QUBO-Chimera)

--- a/test/chimera.jl
+++ b/test/chimera.jl
@@ -19,6 +19,18 @@ function _edge_coordinate_pairs(arch::DWave.Chimera)
     )
 end
 
+function _dnx_chimera_edge_coordinate_pairs(arch::DWave.Chimera)
+    m, n = arch.grid_size
+    shore_size = arch.cell_size ÷ 2
+    graph = DWave.dwave_networkx.chimera_graph(m, n, shore_size; coordinates = true)
+    edges = DWave.PythonCall.pyconvert(
+        Vector{Tuple{NTuple{4,Int},NTuple{4,Int}}},
+        DWave.PythonCall.pylist(graph.edges()),
+    )
+
+    return Set(src <= dst ? (src, dst) : (dst, src) for (src, dst) in edges)
+end
+
 Test.@testset "Chimera supports rectangular topology coordinates" begin
     arch = DWave.Chimera(2, 3)
 
@@ -58,6 +70,12 @@ Test.@testset "Chimera layout returns topology graph and geometry" begin
     Test.@test ((0, 0, 1, 0), (0, 1, 1, 0)) in edge_pairs
     Test.@test !(((0, 0, 0, 0), (0, 1, 0, 0)) in edge_pairs)
     Test.@test !(((0, 0, 1, 0), (1, 0, 1, 0)) in edge_pairs)
+end
+
+Test.@testset "Chimera topology matches dwave-networkx coordinate graph" begin
+    arch = DWave.Chimera(2, 3)
+
+    Test.@test _edge_coordinate_pairs(arch) == _dnx_chimera_edge_coordinate_pairs(arch)
 end
 
 Test.@testset "Chimera validates dimensions" begin


### PR DESCRIPTION
## Summary

- Clarifies that `Chimera` coordinate labels use row/column tile coordinates and the `dwave-networkx` `(i, j, u, k)` shore convention.
- Documents that `o = 0` is the vertical inter-tile shore and `o = 1` is the horizontal inter-tile shore.
- Notes that the legacy HFS/alex1770-style writer emits these labels unchanged, preserving the documented row/column, shore-index convention.

## Validation

- Compared the current graph behavior against the pinned local `dwave-networkx==0.8.18` package from CondaPkg; the existing implementation already matches `dwave-networkx`.
- `julia --project=. -e 'include("test/chimera.jl")'` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed. The D-Wave cloud test path skipped because `DWAVE_API_TOKEN` is not set locally.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `1293a76`
- Head branch: `fix/issue-47-chimera-coordinate-convention`
- Stacked status: not stacked; branch was created from current `main`
- Prerequisite PRs: none; PR #46 is already merged

Closes #47
