### PR TITLE
Relax DWave NumPy pin for QiskitOpt compatibility

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,5 +4,6 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.11,<=3.13"
 
 [pip.deps]
+numpy           = "~=2.2.0"
 dwave-ocean-sdk = "==9.3.0"
 dwave_networkx  = "==0.8.18"

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,6 +4,5 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.11,<=3.13"
 
 [pip.deps]
-numpy           = "==2.4.6"
 dwave-ocean-sdk = "==9.3.0"
 dwave_networkx  = "==0.8.18"

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -77,7 +77,32 @@ Test.@testset "Python dependencies match audited stable stack" begin
     pip_deps = condapkg["pip"]["deps"]
 
     Test.@test condapkg["deps"]["python"] == ">=3.11,<=3.13"
-    Test.@test pip_deps["numpy"] == "==2.4.6"
+    Test.@test !haskey(pip_deps, "numpy")
     Test.@test pip_deps["dwave-ocean-sdk"] == "==9.3.0"
     Test.@test pip_deps["dwave_networkx"] == "==0.8.18"
+end
+
+Test.@testset "Python dependency policy allows shared QiskitOpt benchmark env" begin
+    condapkg = TOML.parsefile(joinpath(PACKAGE_ROOT, "CondaPkg.toml"))
+    pip_deps = condapkg["pip"]["deps"]
+
+    qiskitopt_pip_deps = Dict(
+        "numpy" => "~=2.2.0",
+        "qiskit" => "~=2.3.0",
+        "qiskit-aer" => "~=0.17.0",
+        "qiskit-ibm-runtime" => "~=0.46.0",
+        "qiskit-optimization" => "~=0.7.0",
+        "scipy" => "~=1.15.0",
+    )
+
+    merged_pip_deps = copy(qiskitopt_pip_deps)
+
+    for (package, spec) in pip_deps
+        Test.@test !haskey(merged_pip_deps, package)
+        merged_pip_deps[package] = spec
+    end
+
+    Test.@test merged_pip_deps["numpy"] == "~=2.2.0"
+    Test.@test merged_pip_deps["dwave-ocean-sdk"] == "==9.3.0"
+    Test.@test merged_pip_deps["dwave_networkx"] == "==0.8.18"
 end

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -77,7 +77,7 @@ Test.@testset "Python dependencies match audited stable stack" begin
     pip_deps = condapkg["pip"]["deps"]
 
     Test.@test condapkg["deps"]["python"] == ">=3.11,<=3.13"
-    Test.@test !haskey(pip_deps, "numpy")
+    Test.@test pip_deps["numpy"] == "~=2.2.0"
     Test.@test pip_deps["dwave-ocean-sdk"] == "==9.3.0"
     Test.@test pip_deps["dwave_networkx"] == "==0.8.18"
 end
@@ -86,6 +86,7 @@ Test.@testset "Python dependency policy allows shared QiskitOpt benchmark env" b
     condapkg = TOML.parsefile(joinpath(PACKAGE_ROOT, "CondaPkg.toml"))
     pip_deps = condapkg["pip"]["deps"]
 
+    # Mirrors QiskitOpt v0.7.0's CondaPkg.toml for JuliaQUBO/QUBOBenchmarks.jl#19.
     qiskitopt_pip_deps = Dict(
         "numpy" => "~=2.2.0",
         "qiskit" => "~=2.3.0",
@@ -95,12 +96,14 @@ Test.@testset "Python dependency policy allows shared QiskitOpt benchmark env" b
         "scipy" => "~=1.15.0",
     )
 
-    merged_pip_deps = copy(qiskitopt_pip_deps)
+    overlapping_packages = Set(
+        intersect(collect(keys(pip_deps)), collect(keys(qiskitopt_pip_deps))),
+    )
 
-    for (package, spec) in pip_deps
-        Test.@test !haskey(merged_pip_deps, package)
-        merged_pip_deps[package] = spec
-    end
+    Test.@test overlapping_packages == Set(["numpy"])
+    Test.@test pip_deps["numpy"] == qiskitopt_pip_deps["numpy"]
+
+    merged_pip_deps = merge(qiskitopt_pip_deps, pip_deps)
 
     Test.@test merged_pip_deps["numpy"] == "~=2.2.0"
     Test.@test merged_pip_deps["dwave-ocean-sdk"] == "==9.3.0"


### PR DESCRIPTION
## Summary

- Removed DWave's direct `numpy ==2.4.6` pip pin from `CondaPkg.toml`.
- Kept the audited `dwave-ocean-sdk ==9.3.0` and `dwave_networkx ==0.8.18` pins.
- Added a metadata smoke test that verifies DWave no longer contributes a NumPy constraint when combined with QiskitOpt's benchmark stack.

Closes #52

## Tests

- `julia --project=. -e 'include("test/compat_metadata.jl")'`
- `julia --startup-file=no --project=/tmp/dwave-qiskitopt-condapkg-smoke -e 'import Pkg; Pkg.develop(path="/home/bernalde/repos/DWave.jl"); Pkg.add(Pkg.PackageSpec(name="QiskitOpt", version="0.7.0")); Pkg.add("CondaPkg"); import CondaPkg; CondaPkg.resolve()'`
- `julia --startup-file=no --project=/tmp/dwave-qiskitopt-condapkg-smoke -e 'import DWave; import QiskitOpt; numpy = DWave.PythonCall.pyimport("numpy"); println("numpy=", numpy.__version__); println("dwave_system=", DWave.PythonCall.pyimport("dwave.system").__name__); println("qiskit=", DWave.PythonCall.pyimport("qiskit").__version__)'`
  - resolved/imported with `numpy=2.2.6`, `dwave_system=dwave.system`, `qiskit=2.3.1`
- `julia --project=. -e 'import Pkg; Pkg.test()'`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `7138d95b559f4e1000fd14540313f0d981c0a9c4`
- Stacked status: not stacked
- Prerequisite PRs: none
