### PR TITLE
Release DWave v0.7.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"


### PR DESCRIPTION
## Summary

- Bump DWave.jl to `0.7.3`.
- Publish the NumPy compatibility fix from #53 so `Pkg.add("DWave")` can resolve a shared DWave/QiskitOpt benchmark environment.

## Validation

- `julia --project=. -e 'include("test/compat_metadata.jl")'`
- `julia --project=. -e 'import Pkg; Pkg.test()'`

## Related

- Follows #53
- Supports JuliaQUBO/QUBOBenchmarks.jl#19
- Supports JuliaQUBO/QiskitOpt.jl#63
