### PR TITLE
Resolve shared CondaPkg NumPy conflict with CIMOptimizer

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,6 +4,5 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.11,<=3.13"
 
 [pip.deps]
-numpy           = "~=2.2.0"
 dwave-ocean-sdk = "==9.3.0"
 dwave_networkx  = "==0.8.18"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ current `QUBODrivers` interface cleanly.
 ## API Token
 To use D-Wave's QPU it is necessary to obtain an API Token from [Leap](https://cloud.dwavesys.com/leap/).
 
+## Development Checks
+To verify that DWave can share a CondaPkg environment with the other
+Python-backed JuliaQUBO benchmark drivers, run:
+
+```sh
+julia --startup-file=no test/shared_condapkg_resolve.jl
+```
+
 **Disclaimer:** _The D-Wave wrapper for Julia is not officially supported by D-Wave Systems. If you are a commercial customer interested in official support for Julia from D-Wave, let them know!_
 
 **Note**: _If you are using [DWave.jl](https://github.com/JuliaQUBO/DWave.jl) in your project, we recommend you to include the `.CondaPkg` entry in your `.gitignore` file. The PythonCall module will place a lot of files in this folder when building its Python environment._

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -77,35 +77,52 @@ Test.@testset "Python dependencies match audited stable stack" begin
     pip_deps = condapkg["pip"]["deps"]
 
     Test.@test condapkg["deps"]["python"] == ">=3.11,<=3.13"
-    Test.@test pip_deps["numpy"] == "~=2.2.0"
+    Test.@test !haskey(pip_deps, "numpy")
     Test.@test pip_deps["dwave-ocean-sdk"] == "==9.3.0"
     Test.@test pip_deps["dwave_networkx"] == "==0.8.18"
 end
 
-Test.@testset "Python dependency policy allows shared QiskitOpt benchmark env" begin
+Test.@testset "Python dependency policy allows shared benchmark env" begin
     condapkg = TOML.parsefile(joinpath(PACKAGE_ROOT, "CondaPkg.toml"))
     pip_deps = condapkg["pip"]["deps"]
 
-    # Mirrors QiskitOpt v0.7.0's CondaPkg.toml for JuliaQUBO/QUBOBenchmarks.jl#19.
+    # Mirrors the registered Python-backed benchmark tier from issue #55.
+    cimoptimizer_conda_deps = Dict(
+        "python" => ">=3.10,<3.12",
+        "pytorch-cpu" => ">=2.0.1",
+    )
+    cimoptimizer_pip_deps = Dict("cim-optimizer" => "==1.0.4")
     qiskitopt_pip_deps = Dict(
-        "numpy" => "~=2.2.0",
         "qiskit" => "~=2.3.0",
         "qiskit-aer" => "~=0.17.0",
         "qiskit-ibm-runtime" => "~=0.46.0",
         "qiskit-optimization" => "~=0.7.0",
         "scipy" => "~=1.15.0",
     )
-
-    overlapping_packages = Set(
-        intersect(collect(keys(pip_deps)), collect(keys(qiskitopt_pip_deps))),
+    pysa_pip_deps = Dict(
+        "numpy" => ">=1.20.0",
+        "pysa" => "@ git+https://github.com/nasa/pysa@v0.1.0",
     )
 
-    Test.@test overlapping_packages == Set(["numpy"])
-    Test.@test pip_deps["numpy"] == qiskitopt_pip_deps["numpy"]
+    overlapping_pip_packages = Set(
+        intersect(
+            collect(keys(pip_deps)),
+            union(
+                collect(keys(cimoptimizer_pip_deps)),
+                collect(keys(qiskitopt_pip_deps)),
+                collect(keys(pysa_pip_deps)),
+            ),
+        ),
+    )
 
-    merged_pip_deps = merge(qiskitopt_pip_deps, pip_deps)
+    Test.@test haskey(cimoptimizer_conda_deps, "pytorch-cpu")
+    Test.@test !haskey(pip_deps, "numpy")
+    Test.@test overlapping_pip_packages == Set{String}()
 
-    Test.@test merged_pip_deps["numpy"] == "~=2.2.0"
+    merged_pip_deps = merge(cimoptimizer_pip_deps, qiskitopt_pip_deps, pysa_pip_deps, pip_deps)
+
+    Test.@test merged_pip_deps["numpy"] == ">=1.20.0"
     Test.@test merged_pip_deps["dwave-ocean-sdk"] == "==9.3.0"
     Test.@test merged_pip_deps["dwave_networkx"] == "==0.8.18"
+    Test.@test merged_pip_deps["cim-optimizer"] == "==1.0.4"
 end

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -84,9 +84,11 @@ end
 
 Test.@testset "Python dependency policy allows shared benchmark env" begin
     condapkg = TOML.parsefile(joinpath(PACKAGE_ROOT, "CondaPkg.toml"))
+    conda_deps = condapkg["deps"]
     pip_deps = condapkg["pip"]["deps"]
 
-    # Mirrors the registered Python-backed benchmark tier from issue #55.
+    # Mirrors the registered Python-backed benchmark tier from issue #55:
+    # CIMOptimizer v0.2.2, QiskitOpt v0.7.1, and PySA v0.4.2.
     cimoptimizer_conda_deps = Dict(
         "python" => ">=3.10,<3.12",
         "pytorch-cpu" => ">=2.0.1",
@@ -114,8 +116,13 @@ Test.@testset "Python dependency policy allows shared benchmark env" begin
             ),
         ),
     )
+    overlapping_cimoptimizer_conda_packages = Set(
+        intersect(collect(keys(conda_deps)), collect(keys(cimoptimizer_conda_deps))),
+    )
 
-    Test.@test haskey(cimoptimizer_conda_deps, "pytorch-cpu")
+    Test.@test overlapping_cimoptimizer_conda_packages == Set(["python"])
+    Test.@test !haskey(conda_deps, "numpy")
+    Test.@test !haskey(conda_deps, "pytorch-cpu")
     Test.@test !haskey(pip_deps, "numpy")
     Test.@test overlapping_pip_packages == Set{String}()
 

--- a/test/shared_condapkg_resolve.jl
+++ b/test/shared_condapkg_resolve.jl
@@ -1,0 +1,32 @@
+import Pkg
+
+const PACKAGE_ROOT = normpath(joinpath(@__DIR__, ".."))
+
+function _package_version(name::String)
+    versions = [
+        dep.version for dep in values(Pkg.dependencies()) if dep.name == name
+    ]
+
+    return only(versions)
+end
+
+Pkg.activate(; temp = true)
+Pkg.Registry.update()
+
+Pkg.develop(Pkg.PackageSpec(; path = PACKAGE_ROOT))
+Pkg.add([
+    Pkg.PackageSpec(; name = "CIMOptimizer", version = v"0.2.2"),
+    Pkg.PackageSpec(; name = "QiskitOpt", version = v"0.7.1"),
+    Pkg.PackageSpec(; name = "PySA", version = v"0.4.2"),
+    Pkg.PackageSpec(; name = "CondaPkg", version = v"0.2.36"),
+])
+
+import CondaPkg
+
+CondaPkg.resolve()
+
+println("DWave version=", _package_version("DWave"))
+println("CIMOptimizer version=", _package_version("CIMOptimizer"))
+println("QiskitOpt version=", _package_version("QiskitOpt"))
+println("PySA version=", _package_version("PySA"))
+println("Shared CondaPkg resolve succeeded")


### PR DESCRIPTION
## Summary

- Remove DWave's direct PyPI NumPy dependency so shared CondaPkg environments can use the NumPy selected by the conda/PyPI solve.
- Update compatibility metadata tests to enforce that DWave does not own a direct PyPI NumPy policy.
- Add `test/shared_condapkg_resolve.jl` and README documentation for the full Python-backed JuliaQUBO benchmark-tier CondaPkg resolve smoke.

Closes #55.

## Tests

- `julia --project=. -e 'include("test/compat_metadata.jl")'`
- `env JULIA_DEPOT_PATH=/tmp/dwave-issue55-pair/depot JULIA_PKG_PRECOMPILE_AUTO=0 julia --startup-file=no --project=/tmp/dwave-issue55-pair/project -e 'import Pkg; Pkg.Registry.update(); Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.add([Pkg.PackageSpec(name="CIMOptimizer", version=v"0.2.2"), Pkg.PackageSpec(name="CondaPkg", version=v"0.2.36")]); import CondaPkg; CondaPkg.resolve(); println("DWave + CIMOptimizer CondaPkg resolve succeeded")'`
- `env JULIA_DEPOT_PATH=/tmp/dwave-issue55-full/depot JULIA_PKG_PRECOMPILE_AUTO=0 julia --startup-file=no test/shared_condapkg_resolve.jl`
- `julia --project=. -e 'import Pkg; Pkg.test()'`

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-55-shared-condapkg-numpy`
- Branch point: `origin/main`
- Stacked status: not stacked
- Prerequisite PRs: none
