### PR TITLE
Release DWave v0.7.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"


### PR DESCRIPTION
## Summary

- Bump DWave.jl from v0.7.3 to v0.7.4.
- Patch release for the shared CondaPkg environment NumPy policy fix merged in #56.

## Tests

- `julia --project=. -e 'include("test/compat_metadata.jl")'`
- `julia --project=. -e 'import Pkg; Pkg.test()'`

## Notes

- A local `julia +release --project=. -e 'include("test/compat_metadata.jl")'` run selected Julia 1.12 and failed before the package checks because the checked-in manifest could not locate `MbedTLS_jll`; CI covers Julia 1.10 and latest stable 1.x.
