### PR TITLE
Release v0.7.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"


### PR DESCRIPTION
## Summary

- Bump `DWave` from `0.7.4` to `0.7.5`.

## Checks

- `git diff --check`
- `julia --project=. --startup-file=no -e 'import Pkg; Pkg.test()'`

## Release Notes

This patch release includes the fix from #59 to expose returned embeddings for supplied D-Wave samplers.
