### PR TITLE
Release v0.7.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DWave"
 uuid = "4d534982-bf11-4157-9e48-fe3a62208a50"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"


### PR DESCRIPTION
## Summary

- Bump DWave from v0.7.5 to v0.7.6.
- Release the topology plotting helpers merged in #62.

## Verification

- `DWAVE_API_TOKEN= JULIA_DEPOT_PATH=/home/bernalde/repos/DWave.jl/.julia-depot julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`
  - Passed.
  - Live `DWave.Optimizer` tests were skipped because `DWAVE_API_TOKEN` is empty.
