### PR TITLE
ci: disable unused coverage instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,7 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
         env:
           DWAVE_API_TOKEN: ${{ secrets.DWAVE_API_TOKEN }}
-      # - uses: julia-actions/julia-processcoverage@v1
-      # - uses: codecov/codecov-action@v2
-      #   with:
-      #     file: lcov.info


### PR DESCRIPTION
## Summary

- disable unused coverage instrumentation across the full DWave Julia/OS matrix
- retain every backend, parity, topology, and QUBODrivers test on every existing matrix leg
- remove stale commented coverage/upload configuration

## Validation

- `actionlint`
- `git diff --check`
- full Julia 1.10/current × Ubuntu/Windows CI matrix (post-push)

## Measurement

Issue #67 recorded 34.6 aggregate runner-minutes. Current-Julia test logs showed 92 dependencies precompiled under coverage in 166 seconds on Ubuntu and 217 seconds on Windows.

- attempt 1: 32.5 aggregate runner-minutes; longest job 11m07s
- warm rerun: 29.6 aggregate runner-minutes; longest job 10m06s
- sampled CI logs show `coverage=false`; both complete four-job matrices passed with every backend and interface test retained

The warm rerun used 2.9 fewer aggregate runner-minutes than attempt 1 and 5.0 fewer than the audited baseline. These timings still include material runner/cache variance, so the reliable change is removal of unused coverage work from all four jobs.

## Branch Hygiene

- Base: `main` at `0d4d024046b0cde8e9b4895d41e074be24fa7d96`
- Not stacked; open PR #66 changes `test/compat_metadata.jl`, not the workflow changed here.

Closes #67
